### PR TITLE
Fixed compile errors

### DIFF
--- a/src/plugin/FrameGraphManager.cpp
+++ b/src/plugin/FrameGraphManager.cpp
@@ -3,18 +3,19 @@
 // Wisp plug-in
 #include "frame_graph/frame_graph.hpp"
 
+// TODO: Find the best order of include in alphabetical order without breaking the dependencies
 // Wisp rendering framework
-#include "render_tasks/d3d12_build_acceleration_structures.hpp"
-#include "render_tasks/d3d12_cubemap_convolution.hpp"
 #include "render_tasks/d3d12_deferred_composition.hpp"
 #include "render_tasks/d3d12_deferred_main.hpp"
 #include "render_tasks/d3d12_deferred_render_target_copy.hpp"
-#include "render_tasks/d3d12_depth_data_readback.hpp"
-#include "render_tasks/d3d12_equirect_to_cubemap.hpp"
-#include "render_tasks/d3d12_pixel_data_readback.hpp"
-#include "render_tasks/d3d12_post_processing.hpp"
 #include "render_tasks/d3d12_raytracing_task.hpp"
 #include "render_tasks/d3d12_rt_hybrid_task.hpp"
+#include "render_tasks/d3d12_equirect_to_cubemap.hpp"
+#include "render_tasks/d3d12_cubemap_convolution.hpp"
+#include "render_tasks/d3d12_depth_data_readback.hpp"
+#include "render_tasks/d3d12_pixel_data_readback.hpp"
+#include "render_tasks/d3d12_post_processing.hpp"
+#include "render_tasks/d3d12_build_acceleration_structures.hpp"
 
 namespace wmr
 {

--- a/src/plugin/overrides/UIOverride.cpp
+++ b/src/plugin/overrides/UIOverride.cpp
@@ -7,10 +7,6 @@ namespace wmr
 	{
 	}
 
-	WispUIRenderer::~WispUIRenderer()
-	{
-	}
-
 	MHWRender::MSceneRender::MSceneFilterOption WispUIRenderer::renderFilterOverride()
 	{
 		return MHWRender::MSceneRender::kRenderNonShadedItems;


### PR DESCRIPTION
## Description
Changed the order of includes in the frame graph manager.
UI override destructor implementation is no longer needed due to the usage of `=default` in the header file.

## Motivation and Context
The master branch was broken, so fixing it was the highest priority.

## How Has This Been Tested?
- Tested the Maya plug-in.
- Tested Wisp build.
- Tested Wisp demo project.

## Screenshots (if appropriate):
Not applicable.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ X ] I have updated the documentation accordingly.
