### PR TITLE
Feature material parsing

### DIFF
--- a/src/plugin/callback_manager.cpp
+++ b/src/plugin/callback_manager.cpp
@@ -1,5 +1,7 @@
 #include "callback_manager.hpp"
 
+#include <algorithm>
+
 // Maya API
 #include <maya/MCallbackIdArray.h>
 
@@ -28,6 +30,19 @@ namespace wmr
 	{
 		// Save the callback ID for future use
 		m_callback_vector.push_back(mcid);
+	}
+
+	void CallbackManager::UnregisterCallback(MCallbackId mcid)
+	{
+		auto it = std::find_if(m_callback_vector.begin(), m_callback_vector.end(), [&mcid] (const std::vector<MCallbackId>::value_type& vt)
+		{
+			return vt == mcid;
+		});
+		if (it != m_callback_vector.end())
+		{
+			MMessage::removeCallback(mcid);
+			m_callback_vector.erase(it);
+		}
 	}
 
 	void CallbackManager::Reset()

--- a/src/plugin/callback_manager.hpp
+++ b/src/plugin/callback_manager.hpp
@@ -37,6 +37,12 @@ namespace wmr
 		 *  /param msid Callback id. */
 		void RegisterCallback(MCallbackId mcid);
 
+		//! Unregisters a callback
+		/*! Used to unregister callbacks using a MCallbackId structure.
+		 *
+		 *  /param msid Callback id. */
+		void UnregisterCallback(MCallbackId mcid);
+
 		//! Reset the callback manager
 		/*! If any callbacks have been set, this function will make sure that they are properly disposed of.
 		 *  

--- a/src/plugin/parsers/material_parser.cpp
+++ b/src/plugin/parsers/material_parser.cpp
@@ -80,6 +80,8 @@ namespace wmr
 				break;
 			}
 		}
+
+		material->UpdateConstantBuffer();
 	}
 } /* namespace wmr */
 

--- a/src/plugin/parsers/material_parser.cpp
+++ b/src/plugin/parsers/material_parser.cpp
@@ -128,13 +128,8 @@ void wmr::MaterialParser::OnMeshAdded(const MFnMesh& mesh)
 
 					// Wisp material
 					SurfaceShaderShadingEngineRelation *shader_relation = material_manager.DoesSurfaceShaderExist(surface_shader_plug);
-					wr::MaterialHandle material_handle;
-					// Create a new material if none exists yet
-					if (shader_relation == nullptr)
-					{
-						MObject mesh_object = mesh.object();
-						material_handle = material_manager.CreateMaterial(mesh_object, shading_engine, surface_shader_plug);
-					}
+					MObject mesh_object = mesh.object();
+					wr::MaterialHandle material_handle = material_manager.CreateMaterial(mesh_object, shading_engine, surface_shader_plug);
 
 					// Get a Wisp material for this handle
 					auto material = material_manager.GetWispMaterial(material_handle);
@@ -219,6 +214,26 @@ void wmr::MaterialParser::OnMeshAdded(const MFnMesh& mesh)
 				break;
 		}
 	}
+}
+
+void wmr::MaterialParser::ConnectShaderToShadingEngine(MPlug & surface_shader, MObject & shading_engine)
+{
+	m_renderer.GetMaterialManager().ConnectShaderToShadingEngine(surface_shader, shading_engine);
+}
+
+void wmr::MaterialParser::DisconnectShaderFromShadingEngine(MPlug & surface_shader, MObject & shading_engine)
+{
+	m_renderer.GetMaterialManager().DisconnectShaderFromShadingEngine(surface_shader, shading_engine);
+}
+
+void wmr::MaterialParser::ConnectMeshToShadingEngine(MFnMesh & fnmesh, MObject & shading_engine)
+{
+	m_renderer.GetMaterialManager().ConnectMeshToShadingEngine(fnmesh, shading_engine);
+}
+
+void wmr::MaterialParser::DisconnectMeshFromShadingEngine(MFnMesh & fnmesh, MObject & shading_engine)
+{
+	m_renderer.GetMaterialManager().DisconnectMeshFromShadingEngine(fnmesh, shading_engine);
 }
 
 const wmr::detail::SurfaceShaderType wmr::MaterialParser::GetShaderType(const MObject& node)

--- a/src/plugin/parsers/material_parser.cpp
+++ b/src/plugin/parsers/material_parser.cpp
@@ -74,7 +74,7 @@ namespace wmr
 
 
 // https://nccastaff.bournemouth.ac.uk/jmacey/RobTheBloke/www/research/maya/mfnmesh.htm
-void wmr::MaterialParser::Parse(const MFnMesh& mesh)
+void wmr::MaterialParser::OnMeshAdded(const MFnMesh& mesh)
 {
 	auto material_manager = m_renderer.GetMaterialManager();
 	auto texture_manager = m_renderer.GetTextureManager();

--- a/src/plugin/parsers/material_parser.cpp
+++ b/src/plugin/parsers/material_parser.cpp
@@ -117,6 +117,10 @@ void wmr::MaterialParser::ParseShadingEngineToWispMaterial(MObject & shading_eng
 			}
 		}
 	}
+	else
+	{
+
+	}
 
 	MObject mesh_object = fnmesh.value();
 	material_handle = material_manager.CreateMaterial(mesh_object, shading_engine, surface_shader_plug);
@@ -169,7 +173,7 @@ void wmr::MaterialParser::ParseShadingEngineToWispMaterial(MObject & shading_eng
 }
 
 // https://nccastaff.bournemouth.ac.uk/jmacey/RobTheBloke/www/research/maya/mfnmesh.htm
-void wmr::MaterialParser::OnMeshAdded(const MFnMesh& mesh)
+void wmr::MaterialParser::OnMeshAdded(MFnMesh& mesh)
 {
 	// Number of instances of this mesh
 	std::uint32_t instance_count = mesh.parentCount();

--- a/src/plugin/parsers/material_parser.cpp
+++ b/src/plugin/parsers/material_parser.cpp
@@ -76,8 +76,8 @@ namespace wmr
 // https://nccastaff.bournemouth.ac.uk/jmacey/RobTheBloke/www/research/maya/mfnmesh.htm
 void wmr::MaterialParser::OnMeshAdded(const MFnMesh& mesh)
 {
-	auto material_manager = m_renderer.GetMaterialManager();
-	auto texture_manager = m_renderer.GetTextureManager();
+	auto& material_manager = m_renderer.GetMaterialManager();
+	auto& texture_manager = m_renderer.GetTextureManager();
 
 	// Number of instances of this mesh
 	std::uint32_t instance_count = mesh.parentCount();

--- a/src/plugin/parsers/material_parser.cpp
+++ b/src/plugin/parsers/material_parser.cpp
@@ -76,7 +76,7 @@ namespace wmr
 			}
 			case wmr::detail::SurfaceShaderType::ARNOLD_STANDARD_SURFACE_SHADER:
 			{
-				// CHANGE ARNOLD SHADER
+				material_parser->HandleArnoldChange(fn_dep_material, plug, changedPlugName, *material);
 				break;
 			}
 		}
@@ -117,7 +117,6 @@ void wmr::MaterialParser::ParseShadingEngineToWispMaterial(MObject & shading_eng
 
 void wmr::MaterialParser::InitialMaterialBuild(MPlug & surface_shader, detail::SurfaceShaderType shader_type, wr::MaterialHandle material_handle, MaterialManager & material_manager, TextureManager & texture_manager)
 {
-
 	// Get a Wisp material for this handle
 	auto material = material_manager.GetWispMaterial(material_handle);
 	MObject surface_shader_object = surface_shader.node();
@@ -250,7 +249,11 @@ void wmr::MaterialParser::OnRemoveSurfaceShader(MPlug & surface_shader)
 
 void wmr::MaterialParser::ConnectShaderToShadingEngine(MPlug & surface_shader, MObject & shading_engine)
 {
-	m_renderer.GetMaterialManager().ConnectShaderToShadingEngine(surface_shader, shading_engine);
+	m_renderer.GetMaterialManager().ConnectShaderToShadingEngine(surface_shader, shading_engine, true);
+
+	// Find if shader has callback
+	MObject surface_shader_object = surface_shader.node();
+	SubscribeSurfaceShader(surface_shader_object);
 }
 
 void wmr::MaterialParser::DisconnectShaderFromShadingEngine(MPlug & surface_shader, MObject & shading_engine)
@@ -585,7 +588,10 @@ void wmr::MaterialParser::HandlePhongChange(MFnDependencyNode & fn, MPlug & plug
 void wmr::MaterialParser::HandleArnoldChange(MFnDependencyNode & fn, MPlug & plug, MString & plug_name, wr::Material & material)
 {
 	// CHANGE Arnold MATERIAL DATA
-	// plug_name defines the attribute that is changed (e.g. "color" or "roughness")
+	MObject plug_object = plug.node();
+	auto data = ParseArnoldStandardSurfaceShaderData(plug_object);
+
+	ConfigureWispMaterial(data, &material, m_renderer.GetTextureManager());
 }
 
 const wmr::Renderer & wmr::MaterialParser::GetRenderer()

--- a/src/plugin/parsers/material_parser.cpp
+++ b/src/plugin/parsers/material_parser.cpp
@@ -228,8 +228,8 @@ void wmr::MaterialParser::OnMeshAdded(const MFnMesh& mesh)
 void wmr::MaterialParser::ConnectShaderToShadingEngine(MPlug & surface_shader, MObject & shading_engine)
 {
 	auto shader_relation = m_renderer.GetMaterialManager().DoesSurfaceShaderExist(surface_shader);
-	// Surface shader exists
-	if (shader_relation != nullptr)
+	// Surface shader doesn't exists
+	if (shader_relation == nullptr)
 	{
 		ParseShadingEngineToWispMaterial(shading_engine);
 	}

--- a/src/plugin/parsers/material_parser.hpp
+++ b/src/plugin/parsers/material_parser.hpp
@@ -90,6 +90,12 @@ namespace wmr
 		~MaterialParser() = default;
 
 		void OnMeshAdded(const MFnMesh& mesh);
+
+		void ConnectShaderToShadingEngine(MPlug & surface_shader, MObject & shading_engine);
+		void DisconnectShaderFromShadingEngine(MPlug & surface_shader, MObject & shading_engine);
+		void ConnectMeshToShadingEngine(MFnMesh & fnmesh, MObject & shading_engine);
+		void DisconnectMeshFromShadingEngine(MFnMesh & fnmesh, MObject & shading_engine);
+
 		void HandleLambertChange(MFnDependencyNode &fn, MPlug & plug, MString & plug_name, wr::Material & material);
 		void HandlePhongChange(MFnDependencyNode &fn, MPlug & plug, MString & plug_name, wr::Material & material);
 		const Renderer & GetRenderer();

--- a/src/plugin/parsers/material_parser.hpp
+++ b/src/plugin/parsers/material_parser.hpp
@@ -4,6 +4,8 @@
 
 // Maya API
 #include <maya/MApiNamespace.h>
+#include <maya/MObject.h>
+#include <maya/MMessage.h>
 
 // C++ standard
 #include <optional>
@@ -88,16 +90,25 @@ namespace wmr
 		~MaterialParser() = default;
 
 		void Parse(const MFnMesh& mesh);
-		const std::optional<MObject> GetMeshObjectFromMaterial(MObject & object);
 		void HandleLambertChange(MFnDependencyNode &fn, MPlug & plug, MString & plug_name, wr::Material & material);
 		void HandlePhongChange(MFnDependencyNode &fn, MPlug & plug, MString & plug_name, wr::Material & material);
 		const Renderer & GetRenderer();
 
+		struct ShaderDirtyData
+		{
+			MCallbackId callback_id;				// When removing callbacks, use this id to find what callback must be deleted
+			wmr::MaterialParser * material_parser;	// Pointer to the material parser
+			MObject shading_engine;					// Shading engine
+		};
+
 	private:
+		const void SubscribeSurfaceShader(MObject actual_surface_shader, MObject shading_engine);
+		const std::optional<MPlug> GetSurfaceShader(const MObject& node);
+		const std::optional<MPlug> GetActualSurfaceShaderPlug(const MPlug & surface_shader_plug);
+
 		const detail::SurfaceShaderType GetShaderType(const MObject& node);
 		const std::optional<MString> GetPlugTexture(MPlug& plug);
 		const MPlug GetPlugByName(const MObject& node, MString name);
-		const std::optional<MPlug> GetSurfaceShader(const MObject& node);
 
 		void ConfigureWispMaterial(const detail::ArnoldStandardSurfaceShaderData& data, wr::Material* material, MString mesh_name, TextureManager& texture_manager) const;
 
@@ -105,13 +116,9 @@ namespace wmr
 
 		// Material parsing
 		MColor GetColor(MFnDependencyNode & fn, MString & plug_name);
+		std::vector<ShaderDirtyData*> shader_dirty_datas;
 
 	private:
-		// std::pair
-		//    first: MObject, connected lambert plug
-		//    second: MObject, MFnMesh.object()
-		std::vector<std::pair<MObject, MObject>> mesh_material_relations;
-
 		Renderer& m_renderer;
 	};
 }

--- a/src/plugin/parsers/material_parser.hpp
+++ b/src/plugin/parsers/material_parser.hpp
@@ -90,7 +90,7 @@ namespace wmr
 		MaterialParser();
 		~MaterialParser() = default;
 
-		void OnMeshAdded(const MFnMesh& mesh);
+		void OnMeshAdded(MFnMesh& mesh);
 
 		void ConnectShaderToShadingEngine(MPlug & surface_shader, MObject & shading_engine);
 		void DisconnectShaderFromShadingEngine(MPlug & surface_shader, MObject & shading_engine);

--- a/src/plugin/parsers/material_parser.hpp
+++ b/src/plugin/parsers/material_parser.hpp
@@ -93,8 +93,8 @@ namespace wmr
 
 		void ConnectShaderToShadingEngine(MPlug & surface_shader, MObject & shading_engine);
 		void DisconnectShaderFromShadingEngine(MPlug & surface_shader, MObject & shading_engine);
-		void ConnectMeshToShadingEngine(MFnMesh & fnmesh, MObject & shading_engine);
-		void DisconnectMeshFromShadingEngine(MFnMesh & fnmesh, MObject & shading_engine);
+		void ConnectMeshToShadingEngine(MObject & mesh, MObject & shading_engine);
+		void DisconnectMeshFromShadingEngine(MObject & mesh, MObject & shading_engine);
 
 		void HandleLambertChange(MFnDependencyNode &fn, MPlug & plug, MString & plug_name, wr::Material & material);
 		void HandlePhongChange(MFnDependencyNode &fn, MPlug & plug, MString & plug_name, wr::Material & material);
@@ -108,7 +108,9 @@ namespace wmr
 		};
 
 	private:
-		const void SubscribeSurfaceShader(MObject actual_surface_shader, MObject shading_engine);
+		void SubscribeSurfaceShader(MObject actual_surface_shader, MObject shading_engine);
+		void ParseShadingEngineToWispMaterial(MObject & shading_engine, std::optional<MObject> fnmesh = std::nullopt);
+
 		const std::optional<MPlug> GetSurfaceShader(const MObject& node);
 		const std::optional<MPlug> GetActualSurfaceShaderPlug(const MPlug & surface_shader_plug);
 

--- a/src/plugin/parsers/material_parser.hpp
+++ b/src/plugin/parsers/material_parser.hpp
@@ -91,28 +91,31 @@ namespace wmr
 		~MaterialParser() = default;
 
 		void OnMeshAdded(MFnMesh& mesh);
+		void OnCreateSurfaceShader(MPlug & surface_shader);
+		void OnRemoveSurfaceShader(MPlug & surface_shader);
+		
 
 		void ConnectShaderToShadingEngine(MPlug & surface_shader, MObject & shading_engine);
 		void DisconnectShaderFromShadingEngine(MPlug & surface_shader, MObject & shading_engine);
 		void ConnectMeshToShadingEngine(MObject & mesh, MObject & shading_engine);
 		void DisconnectMeshFromShadingEngine(MObject & mesh, MObject & shading_engine);
 
-		const detail::SurfaceShaderType GetShaderType(const MObject& node);
-
 		void HandleLambertChange(MFnDependencyNode &fn, MPlug & plug, MString & plug_name, wr::Material & material);
 		void HandlePhongChange(MFnDependencyNode &fn, MPlug & plug, MString & plug_name, wr::Material & material);
 		void HandleArnoldChange(MFnDependencyNode &fn, MPlug & plug, MString & plug_name, wr::Material & material);
+
 		const Renderer & GetRenderer();
+		const detail::SurfaceShaderType GetShaderType(const MObject& node);
 
 		struct ShaderDirtyData
 		{
 			MCallbackId callback_id;				// When removing callbacks, use this id to find what callback must be deleted
 			wmr::MaterialParser * material_parser;	// Pointer to the material parser
-			MObject shading_engine;					// Shading engine
+			MObject surface_shader;					// Surface shader
 		};
 
 	private:
-		void SubscribeSurfaceShader(MObject actual_surface_shader, MObject shading_engine);
+		void SubscribeSurfaceShader(MObject & actual_surface_shader);
 		void ParseShadingEngineToWispMaterial(MObject & shading_engine, std::optional<MObject> fnmesh = std::nullopt);
 
 		const std::optional<MPlug> GetSurfaceShader(const MObject& node);

--- a/src/plugin/parsers/material_parser.hpp
+++ b/src/plugin/parsers/material_parser.hpp
@@ -89,7 +89,8 @@ namespace wmr
 		MaterialParser();
 		~MaterialParser() = default;
 
-		void Parse(const MFnMesh& mesh);
+		void OnMeshAdded(const MFnMesh& mesh);
+		const std::optional<MObject> GetMeshObjectFromMaterial(MObject & object);
 		void HandleLambertChange(MFnDependencyNode &fn, MPlug & plug, MString & plug_name, wr::Material & material);
 		void HandlePhongChange(MFnDependencyNode &fn, MPlug & plug, MString & plug_name, wr::Material & material);
 		const Renderer & GetRenderer();

--- a/src/plugin/parsers/material_parser.hpp
+++ b/src/plugin/parsers/material_parser.hpp
@@ -90,10 +90,11 @@ namespace wmr
 		MaterialParser();
 		~MaterialParser() = default;
 
+		void InitialMaterialBuild(MPlug & surface_shader, detail::SurfaceShaderType shader_type, wr::MaterialHandle material_handle, MaterialManager & material_manager, TextureManager & texture_manager);
+
 		void OnMeshAdded(MFnMesh& mesh);
 		void OnCreateSurfaceShader(MPlug & surface_shader);
 		void OnRemoveSurfaceShader(MPlug & surface_shader);
-		
 
 		void ConnectShaderToShadingEngine(MPlug & surface_shader, MObject & shading_engine);
 		void DisconnectShaderFromShadingEngine(MPlug & surface_shader, MObject & shading_engine);

--- a/src/plugin/parsers/material_parser.hpp
+++ b/src/plugin/parsers/material_parser.hpp
@@ -118,7 +118,7 @@ namespace wmr
 
 	private:
 		void SubscribeSurfaceShader(MObject & actual_surface_shader);
-		void ParseShadingEngineToWispMaterial(MObject & shading_engine, std::optional<MObject> fnmesh = std::nullopt);
+		void ParseShadingEngineToWispMaterial(MObject & shading_engine, MObject & fnmesh);
 
 		const std::optional<MPlug> GetSurfaceShader(const MObject& node);
 		const std::optional<MPlug> GetActualSurfaceShaderPlug(const MPlug & surface_shader_plug);

--- a/src/plugin/parsers/material_parser.hpp
+++ b/src/plugin/parsers/material_parser.hpp
@@ -96,6 +96,8 @@ namespace wmr
 		void ConnectMeshToShadingEngine(MObject & mesh, MObject & shading_engine);
 		void DisconnectMeshFromShadingEngine(MObject & mesh, MObject & shading_engine);
 
+		const detail::SurfaceShaderType GetShaderType(const MObject& node);
+
 		void HandleLambertChange(MFnDependencyNode &fn, MPlug & plug, MString & plug_name, wr::Material & material);
 		void HandlePhongChange(MFnDependencyNode &fn, MPlug & plug, MString & plug_name, wr::Material & material);
 		const Renderer & GetRenderer();
@@ -114,7 +116,6 @@ namespace wmr
 		const std::optional<MPlug> GetSurfaceShader(const MObject& node);
 		const std::optional<MPlug> GetActualSurfaceShaderPlug(const MPlug & surface_shader_plug);
 
-		const detail::SurfaceShaderType GetShaderType(const MObject& node);
 		const std::optional<MString> GetPlugTexture(MPlug& plug);
 		const MPlug GetPlugByName(const MObject& node, MString name);
 

--- a/src/plugin/parsers/material_parser.hpp
+++ b/src/plugin/parsers/material_parser.hpp
@@ -90,7 +90,6 @@ namespace wmr
 		~MaterialParser() = default;
 
 		void OnMeshAdded(const MFnMesh& mesh);
-		const std::optional<MObject> GetMeshObjectFromMaterial(MObject & object);
 		void HandleLambertChange(MFnDependencyNode &fn, MPlug & plug, MString & plug_name, wr::Material & material);
 		void HandlePhongChange(MFnDependencyNode &fn, MPlug & plug, MString & plug_name, wr::Material & material);
 		const Renderer & GetRenderer();

--- a/src/plugin/parsers/model_parser.cpp
+++ b/src/plugin/parsers/model_parser.cpp
@@ -342,10 +342,15 @@ namespace wmr
 		wmr::ModelParser* model_parser = reinterpret_cast< wmr::ModelParser* >( client_data );
 		// Add the mesh
 		model_parser->MeshAdded(mesh);
+
+
+
 		if (model_parser->mesh_add_callback != nullptr)
 		{
 			model_parser->mesh_add_callback(mesh);
 		}
+
+
 
 		// Unregister the callback
 		auto findCallback = [ &object ]( std::pair<MObject, MCallbackId> pair ) -> bool
@@ -486,14 +491,6 @@ void wmr::ModelParser::MeshAdded( MFnMesh & fnmesh )
 
 	bool model_reloaded = false;
 	wr::Model* model = m_renderer.GetModelManager().AddModel( fnmesh.name(), { mesh_data }, model_reloaded );
-
-
-	auto default_material = m_renderer.GetMaterialManager().GetDefaultMaterial();
-
-	for( auto& m : model->m_meshes )
-	{
-		m.second = default_material;
-	}
 	m_renderer.GetD3D12Renderer().WaitForAllPreviousWork();
 	auto model_node = m_renderer.GetScenegraph().CreateChild<wr::MeshNode>( nullptr, model );
 	MStatus status;
@@ -517,8 +514,6 @@ void wmr::ModelParser::MeshAdded( MFnMesh & fnmesh )
 	}
 
 	updateTransform( transform, model_node );
-
-	model->m_meshes[0].second = m_renderer.GetMaterialManager().GetDefaultMaterial();
 
 	m_object_transform_vector.push_back( std::make_pair( fnmesh.object(), model_node ) );
 

--- a/src/plugin/parsers/model_parser.cpp
+++ b/src/plugin/parsers/model_parser.cpp
@@ -341,7 +341,11 @@ namespace wmr
 
 		wmr::ModelParser* model_parser = reinterpret_cast< wmr::ModelParser* >( client_data );
 		// Add the mesh
-		model_parser->MeshAdded( mesh );
+		model_parser->MeshAdded(mesh);
+		if (model_parser->mesh_add_callback != nullptr)
+		{
+			model_parser->mesh_add_callback(mesh);
+		}
 
 		// Unregister the callback
 		auto findCallback = [ &object ]( std::pair<MObject, MCallbackId> pair ) -> bool
@@ -371,7 +375,6 @@ namespace wmr
 			std::iter_swap( it, it_end );
 			MMessage::removeCallback( it_end->second );
 			model_parser->m_mesh_added_callback_vector.pop_back();
-
 		}
 
 	}
@@ -565,6 +568,15 @@ void wmr::ModelParser::Update()
 
 	}
 	m_changed_mesh_vector.clear();
+}
+
+void wmr::ModelParser::SetMeshAddCallback(std::function<void(MFnMesh&)> callback)
+{
+	if (mesh_add_callback != nullptr)
+	{
+		assert(false);
+	}
+	mesh_add_callback = callback;
 }
 
 std::shared_ptr<wr::MeshNode> wmr::ModelParser::GetWRModel(MObject & maya_object)

--- a/src/plugin/parsers/model_parser.cpp
+++ b/src/plugin/parsers/model_parser.cpp
@@ -578,10 +578,9 @@ std::shared_ptr<wr::MeshNode> wmr::ModelParser::GetWRModel(MObject & maya_object
 		return false;
 	};
 	auto it = std::find_if(m_object_transform_vector.begin(), m_object_transform_vector.end(), findCallback);
-	if (it->first != maya_object)
+	if (it != m_object_transform_vector.end())
 	{
-		assert(false);
-		// find_if returns last element even if it is not a positive result
+		return it->second;
 	}
-	return it->second;
+	return nullptr;//std::make_shared<wr::MeshNode>();
 }

--- a/src/plugin/parsers/model_parser.hpp
+++ b/src/plugin/parsers/model_parser.hpp
@@ -5,6 +5,7 @@
 #include <vector>
 #include <memory>
 
+#include <functional>
 
 namespace wr
 {
@@ -29,6 +30,8 @@ namespace wmr
 
 		void Update();
 
+		void SetMeshAddCallback(std::function<void(MFnMesh&)> callback);
+
 	private:
 		//callbacks that require private access and are part of the ModelParser.
 		friend void AttributeMeshTransformCallback( MNodeMessage::AttributeMessage msg, MPlug &plug, MPlug &otherPlug, void *clientData );
@@ -41,5 +44,7 @@ namespace wmr
 		std::vector<MObject> m_changed_mesh_vector;
 
 		Renderer& m_renderer;
+
+		std::function<void(MFnMesh&)> mesh_add_callback;
 	};
 }

--- a/src/plugin/parsers/scene_graph_parser.cpp
+++ b/src/plugin/parsers/scene_graph_parser.cpp
@@ -99,6 +99,11 @@ void MaterialMeshAddedCallback(MObject& node, void* client_data)
 	}
 }
 
+void ShadingEngineRemoveCallback(MObject& node, void* client_data)
+{
+	int x= 0;
+}
+
 void ConnectionAddedCallback(MPlug& src_plug, MPlug& dest_plug, bool made, void* client_data)
 {
 	auto* material_parser = reinterpret_cast<wmr::MaterialParser*>(client_data);
@@ -184,6 +189,15 @@ void wmr::ScenegraphParser::Initialize()
 	);
 	AddCallbackValidation(status, addedId);
 
+	// Mesh added (material)
+	addedId = MDGMessage::addNodeRemovedCallback(
+		ShadingEngineRemoveCallback,
+		"shadingEngine",
+		m_material_parser.get(),
+		&status
+	);
+	AddCallbackValidation(status, addedId);
+
 	// Mesh removed 
 	addedId = MDGMessage::addNodeRemovedCallback(
 		MeshRemovedCallback,
@@ -259,6 +273,18 @@ void wmr::ScenegraphParser::Initialize()
 void wmr::ScenegraphParser::Update()
 {
 	m_model_parser->Update();
+}
+
+void wmr::ScenegraphParser::AddCallbackValidation(MStatus status, MCallbackId id)
+{
+	if (status == MS::kSuccess)
+	{
+		CallbackManager::GetInstance().RegisterCallback(id);
+	}
+	else
+	{
+		assert(false);
+	}
 }
 
 wmr::ModelParser & wmr::ScenegraphParser::GetModelParser() const noexcept

--- a/src/plugin/parsers/scene_graph_parser.cpp
+++ b/src/plugin/parsers/scene_graph_parser.cpp
@@ -78,6 +78,24 @@ void MaterialMeshAddedCallback(MObject& node, void* client_data)
 	}
 }
 
+void ConnectionAddedCallback(MPlug& srcPlug, MPlug& destPlug, bool made, void* clientData)
+{
+	// Get plug types
+	auto srcType = srcPlug.node().apiType();
+	auto destType = destPlug.node().apiType();
+
+	// Check if a connection is made or broken
+	if (made)
+	{
+		// Check if shading engine is connected to mesh
+	}
+	// Connection broken
+	else
+	{
+		// Check if shading engine is disconnected to mesh
+	}
+}
+
 wmr::ScenegraphParser::ScenegraphParser( ) :
 	m_render_system( dynamic_cast< const ViewportRendererOverride* >(
 		MHWRender::MRenderer::theRenderer()->findRenderOverride( settings::VIEWPORT_OVERRIDE_NAME )
@@ -103,7 +121,7 @@ void wmr::ScenegraphParser::Initialize()
 		this,
 		&status
 	);
-	AddCallbackId(status, addedId);
+	AddCallbackValidation(status, addedId);
 
 	addedId = MDGMessage::addNodeAddedCallback(
 		MaterialMeshAddedCallback,
@@ -111,7 +129,7 @@ void wmr::ScenegraphParser::Initialize()
 		m_material_parser.get(),
 		&status
 	);
-	AddCallbackId(status, addedId);	
+	AddCallbackValidation(status, addedId);
 
 	addedId = MDGMessage::addNodeRemovedCallback(
 		MeshRemovedCallback,
@@ -119,7 +137,14 @@ void wmr::ScenegraphParser::Initialize()
 		this,
 		&status
 	);
-	AddCallbackId(status, addedId);
+	AddCallbackValidation(status, addedId);
+
+	addedId = MDGMessage::addConnectionCallback(
+		ConnectionAddedCallback,
+		m_material_parser.get(),
+		&status
+	);
+	AddCallbackValidation(status, addedId);
 
 	MStatus load_status = MS::kSuccess;
 	MItDag itt( MItDag::kDepthFirst, MFn::kMesh, &load_status );
@@ -140,7 +165,7 @@ void wmr::ScenegraphParser::Initialize()
 	}
 }
 
-void wmr::ScenegraphParser::AddCallbackId(MStatus status, MCallbackId id)
+void wmr::ScenegraphParser::AddCallbackValidation(MStatus status, MCallbackId id)
 {
 	if (status == MS::kSuccess)
 	{

--- a/src/plugin/parsers/scene_graph_parser.cpp
+++ b/src/plugin/parsers/scene_graph_parser.cpp
@@ -111,6 +111,7 @@ void ConnectionAddedCallback(MPlug& src_plug, MPlug& dest_plug, bool made, void*
 			// The type is UNSUPPORTED if we don't support it or if it's not a surface shader
 			if (shaderType != wmr::detail::SurfaceShaderType::UNSUPPORTED)
 			{
+				// Check if connection is made
 				if (made)
 				{
 					material_parser->ConnectShaderToShadingEngine(src_plug, dest_object);

--- a/src/plugin/parsers/scene_graph_parser.cpp
+++ b/src/plugin/parsers/scene_graph_parser.cpp
@@ -97,7 +97,7 @@ void ConnectionAddedCallback(MPlug& src_plug, MPlug& dest_plug, bool made, void*
 			{
 				case MFn::kMesh:
 				{
-					MFnMesh src_object(src_plug.node());
+					MObject src_object(src_plug.node());
 					material_parser->ConnectMeshToShadingEngine(src_object, dest_object);
 					break;
 				}

--- a/src/plugin/parsers/scene_graph_parser.cpp
+++ b/src/plugin/parsers/scene_graph_parser.cpp
@@ -120,7 +120,7 @@ void ConnectionAddedCallback(MPlug& src_plug, MPlug& dest_plug, bool made, void*
 			{
 				case MFn::kMesh:
 				{
-					MFnMesh src_object(src_plug.node());
+					MObject src_object(src_plug.node());
 					material_parser->DisconnectMeshFromShadingEngine(src_object, dest_object);
 					break;
 				}

--- a/src/plugin/parsers/scene_graph_parser.hpp
+++ b/src/plugin/parsers/scene_graph_parser.hpp
@@ -32,7 +32,6 @@ namespace wmr
 		void Initialize();
 		void Update();
 
-
 		void AddCallbackValidation(MStatus status, MCallbackId id);
 
 		ModelParser& GetModelParser() const noexcept;

--- a/src/plugin/parsers/scene_graph_parser.hpp
+++ b/src/plugin/parsers/scene_graph_parser.hpp
@@ -30,7 +30,7 @@ namespace wmr
 
 		void Initialize();
 
-		void AddCallbackId(MStatus status, MCallbackId id);
+		void AddCallbackValidation(MStatus status, MCallbackId id);
 
 		ModelParser& GetModelParser() const noexcept;
 		MaterialParser& GetMaterialParser() const noexcept;

--- a/src/plugin/parsers/scene_graph_parser.hpp
+++ b/src/plugin/parsers/scene_graph_parser.hpp
@@ -1,5 +1,11 @@
 #pragma once
+
+// Maya API
+#include <maya/MApiNamespace.h>
+#include <maya/MMessage.h>
+
 #include <memory>
+
 namespace wr
 {
 	class SceneGraph;
@@ -23,6 +29,8 @@ namespace wmr
 		~ScenegraphParser();
 
 		void Initialize();
+
+		void AddCallbackId(MStatus status, MCallbackId id);
 
 		ModelParser& GetModelParser() const noexcept;
 		MaterialParser& GetMaterialParser() const noexcept;

--- a/src/plugin/renderer/material_manager.cpp
+++ b/src/plugin/renderer/material_manager.cpp
@@ -114,7 +114,17 @@ wr::MaterialHandle wmr::MaterialManager::ConnectShaderToShadingEngine(MPlug & su
 }
 
 void wmr::MaterialManager::DisonnectShaderFromShadingEngine(MPlug & surface_shader, MObject & shading_engine)
-{ }
+{ 
+	auto relation = DoesSurfaceShaderExist(surface_shader);
+	if (relation != nullptr)
+	{
+		auto shading_engine_it = relation->FindShadingEngine(shading_engine);
+		if (shading_engine_it != relation->shading_engines.end())
+		{
+			relation->shading_engines.erase(shading_engine_it);
+		}
+	}
+}
 
 void wmr::MaterialManager::ConnectMeshToShadingEngine(MFnMesh & fnmesh, MObject & shading_engine)
 { }

--- a/src/plugin/renderer/material_manager.cpp
+++ b/src/plugin/renderer/material_manager.cpp
@@ -117,7 +117,7 @@ void wmr::MaterialManager::OnRemoveSurfaceShader(MPlug & surface_shader)
 	}
 }
 
-wr::MaterialHandle wmr::MaterialManager::ConnectShaderToShadingEngine(MPlug & surface_shader, MObject & shading_engine)
+wr::MaterialHandle wmr::MaterialManager::ConnectShaderToShadingEngine(MPlug & surface_shader, MObject & shading_engine, bool apply_material)
 {
 	// Find surface shader relationships
 	MObject surface_shader_obj = surface_shader.node();
@@ -130,6 +130,21 @@ wr::MaterialHandle wmr::MaterialManager::ConnectShaderToShadingEngine(MPlug & su
 		{
 			relation->shading_engines.push_back(shading_engine);
 		}
+
+		// Get mesh and bind surface shader
+		if (apply_material)
+		{
+			auto it = std::find_if(m_mesh_shading_relations.begin(), m_mesh_shading_relations.end(), [this, &relation, &shading_engine] (const std::vector<MeshShadingEngineRelation>::value_type& vt)
+			{
+				if (vt.shading_engine == shading_engine)
+				{
+					MObject obj = vt.mesh;
+					this->ApplyMaterialToModel(relation->material_handle, obj);
+				}
+				return false;
+			});
+		}
+
 		return relation->material_handle;
 	}
 	// Surface shader doesn't have a material assigned to it yet
@@ -144,6 +159,20 @@ wr::MaterialHandle wmr::MaterialManager::ConnectShaderToShadingEngine(MPlug & su
 		surface_shader,			// Maya surface shader plug
 		shading_engines			// Vector of shading engines
 	});
+
+	// Get mesh and bind surface shader
+	if (apply_material)
+	{
+		auto it = std::find_if(m_mesh_shading_relations.begin(), m_mesh_shading_relations.end(), [this, &material_handle, &shading_engine] (const std::vector<MeshShadingEngineRelation>::value_type& vt)
+		{
+			if (vt.shading_engine == shading_engine)
+			{
+				MObject obj = vt.mesh;
+				this->ApplyMaterialToModel(material_handle, obj);
+			}
+			return false;
+		});
+	}
 
 	return material_handle;
 }

--- a/src/plugin/renderer/material_manager.cpp
+++ b/src/plugin/renderer/material_manager.cpp
@@ -23,6 +23,8 @@ wmr::MaterialManager::MaterialManager() :
 
 wmr::MaterialManager::~MaterialManager()
 {
+	m_mesh_shading_relations.clear();
+	m_mesh_shading_relations.clear();
 }
 
 void wmr::MaterialManager::Initialize()
@@ -191,7 +193,7 @@ wmr::SurfaceShaderShadingEngineRelation * wmr::MaterialManager::DoesSurfaceShade
 	// Search relationships for shading engines
 	for (auto& relation : m_surface_shader_shading_relations)
 	{
-		if (relation.surface_shader == surface_shader)
+		if (relation.surface_shader.node() == surface_shader.node())
 		{
 			return &relation;
 		}
@@ -225,10 +227,13 @@ void wmr::MaterialManager::ApplyMaterialToModel(wr::MaterialHandle & material_ha
 {
 	
 	std::shared_ptr<wr::MeshNode> wr_mesh_node = GetSceneParser()->GetModelParser().GetWRModel(fnmesh);
-	wr::Model* wr_model = wr_mesh_node->m_model;
-	for (auto& mesh : wr_model->m_meshes)
+	if (wr_mesh_node != nullptr)
 	{
-		mesh.second = material_handle;
+		wr::Model* wr_model = wr_mesh_node->m_model;
+		for (auto& mesh : wr_model->m_meshes)
+		{
+			mesh.second = material_handle;
+		}
 	}
 }
 

--- a/src/plugin/renderer/material_manager.cpp
+++ b/src/plugin/renderer/material_manager.cpp
@@ -160,6 +160,27 @@ wmr::SurfaceShaderShadingEngineRelation * wmr::MaterialManager::DoesMaterialHand
 	return nullptr;
 }
 
+wmr::SurfaceShaderShadingEngineRelation * wmr::MaterialManager::DoesShaderEngineExist(MObject & shading_engine)
+{
+	auto it = std::find_if(m_surface_shader_shading_relations.begin(), m_surface_shader_shading_relations.end(), [&shading_engine] (const std::vector<SurfaceShaderShadingEngineRelation>::value_type& vt)
+	{
+		auto end_it = vt.shading_engines.end();
+		auto shading_engines_it = std::find_if(vt.shading_engines.begin(), end_it, [&shading_engine] (const std::vector<MObject>::value_type& vt)
+		{
+			return (vt == shading_engine);
+		});
+
+		return (shading_engines_it != end_it);
+	});
+
+	if (it != m_surface_shader_shading_relations.end())
+	{
+		return &*it;
+	}
+
+	return nullptr;
+}
+
 wmr::SurfaceShaderShadingEngineRelation * wmr::MaterialManager::DoesSurfaceShaderExist(MPlug & surface_shader)
 {
 	// Search relationships for shading engines
@@ -186,20 +207,11 @@ wmr::ScenegraphParser * wmr::MaterialManager::GetSceneParser()
 
 wr::MaterialHandle wmr::MaterialManager::FindWispMaterialByShadingEngine(MObject & shading_engine)
 {
-	auto it = std::find_if(m_surface_shader_shading_relations.begin(), m_surface_shader_shading_relations.end(), [&shading_engine] (const std::vector<SurfaceShaderShadingEngineRelation>::value_type& vt)
-	{
-		auto end_it = vt.shading_engines.end();
-		auto shading_engines_it = std::find_if(vt.shading_engines.begin(), end_it, [&shading_engine] (const std::vector<MObject>::value_type& vt)
-		{
-			return (vt == shading_engine);
-		});
+	wmr::SurfaceShaderShadingEngineRelation * relation = DoesShaderEngineExist(shading_engine);
 
-		return (shading_engines_it != end_it);
-	});
-
-	if (it != m_surface_shader_shading_relations.end())
+	if (relation != nullptr)
 	{
-		return it->material_handle;
+		return relation->material_handle;
 	}
 	return m_default_material_handle;
 }

--- a/src/plugin/renderer/material_manager.cpp
+++ b/src/plugin/renderer/material_manager.cpp
@@ -18,10 +18,12 @@
 
 wmr::MaterialManager::MaterialManager() :
 	m_scenegraph_parser(nullptr)
-{ }
+{
+}
 
 wmr::MaterialManager::~MaterialManager()
-{ }
+{
+}
 
 void wmr::MaterialManager::Initialize()
 {

--- a/src/plugin/renderer/material_manager.cpp
+++ b/src/plugin/renderer/material_manager.cpp
@@ -64,13 +64,13 @@ wr::MaterialHandle wmr::MaterialManager::CreateMaterial(MObject& mesh, MObject &
 	return material_handle;
 }
 
-void wmr::MaterialManager::OnCreateSurfaceShader(MPlug & surface_shader)
+wmr::SurfaceShaderShadingEngineRelation * wmr::MaterialManager::OnCreateSurfaceShader(MPlug & surface_shader)
 {
 	MObject surface_shader_obj = surface_shader.node();
 	auto relation = DoesSurfaceShaderExist(surface_shader_obj);
 	if (relation != nullptr)
 	{
-		return;
+		return nullptr;
 	}
 	// Surface shader doesn't have a material assigned to it yet
 	// Create Wisp Material handle
@@ -82,7 +82,7 @@ void wmr::MaterialManager::OnCreateSurfaceShader(MPlug & surface_shader)
 		std::vector<MObject>()	// Vector of shading engines
 	});
 
-	return;
+	return &m_surface_shader_shading_relations[m_surface_shader_shading_relations.size() - 1];
 }
 
 void wmr::MaterialManager::OnRemoveSurfaceShader(MPlug & surface_shader)

--- a/src/plugin/renderer/material_manager.cpp
+++ b/src/plugin/renderer/material_manager.cpp
@@ -101,12 +101,11 @@ void wmr::MaterialManager::DisconnectShaderFromShadingEngine(MPlug & surface_sha
 	}
 }
 
-void wmr::MaterialManager::ConnectMeshToShadingEngine(MFnMesh & fnmesh, MObject & shading_engine)
+void wmr::MaterialManager::ConnectMeshToShadingEngine(MObject & mesh, MObject & shading_engine)
 {
-	MObject mesh_obj = fnmesh.object();
-	auto it = std::find_if(m_mesh_shading_relations.begin(), m_mesh_shading_relations.end(), [&mesh_obj] (const std::vector<MeshShadingEngineRelation>::value_type& vt)
+	auto it = std::find_if(m_mesh_shading_relations.begin(), m_mesh_shading_relations.end(), [&mesh] (const std::vector<MeshShadingEngineRelation>::value_type& vt)
 	{
-		return (vt.mesh == mesh_obj);
+		return (vt.mesh == mesh);
 	});
 	// If the mesh already has a shading engine
 	if (it != m_mesh_shading_relations.end())
@@ -117,21 +116,20 @@ void wmr::MaterialManager::ConnectMeshToShadingEngine(MFnMesh & fnmesh, MObject 
 	else
 	{
 		MeshShadingEngineRelation newRelation;
-		newRelation.mesh = mesh_obj;
+		newRelation.mesh = mesh;
 		newRelation.shading_engine = shading_engine;
 		m_mesh_shading_relations.push_back(newRelation);
 	}
 
 	wr::MaterialHandle material_handle = FindWispMaterialByShadingEngine(shading_engine);
-	ApplyMaterialToModel(material_handle, mesh_obj);
+	ApplyMaterialToModel(material_handle, mesh);
 }
 
-void wmr::MaterialManager::DisconnectMeshFromShadingEngine(MFnMesh & fnmesh, MObject & shading_engine, bool reset_material)
+void wmr::MaterialManager::DisconnectMeshFromShadingEngine(MObject & mesh, MObject & shading_engine, bool reset_material)
 {
-	MObject mesh_obj = fnmesh.object();
-	auto it = std::find_if(m_mesh_shading_relations.begin(), m_mesh_shading_relations.end(), [&mesh_obj, &shading_engine] (const std::vector<MeshShadingEngineRelation>::value_type& vt)
+	auto it = std::find_if(m_mesh_shading_relations.begin(), m_mesh_shading_relations.end(), [&mesh, &shading_engine] (const std::vector<MeshShadingEngineRelation>::value_type& vt)
 	{
-		return (vt.mesh == mesh_obj && vt.shading_engine == shading_engine);
+		return (vt.mesh == mesh && vt.shading_engine == shading_engine);
 	});
 	// Found the relation between the two given parameters (mesh and shading engine)
 	if (it != m_mesh_shading_relations.end())
@@ -140,7 +138,6 @@ void wmr::MaterialManager::DisconnectMeshFromShadingEngine(MFnMesh & fnmesh, MOb
 
 		if (reset_material)
 		{
-			MObject mesh = fnmesh.object();
 			ApplyMaterialToModel(m_default_material_handle, mesh);
 		}
 	}

--- a/src/plugin/renderer/material_manager.cpp
+++ b/src/plugin/renderer/material_manager.cpp
@@ -86,7 +86,7 @@ wr::MaterialHandle wmr::MaterialManager::ConnectShaderToShadingEngine(MPlug & su
 	return material_handle;
 }
 
-void wmr::MaterialManager::DisonnectShaderFromShadingEngine(MPlug & surface_shader, MObject & shading_engine)
+void wmr::MaterialManager::DisconnectShaderFromShadingEngine(MPlug & surface_shader, MObject & shading_engine)
 { 
 	auto relation = DoesSurfaceShaderExist(surface_shader);
 	if (relation != nullptr)

--- a/src/plugin/renderer/material_manager.cpp
+++ b/src/plugin/renderer/material_manager.cpp
@@ -46,10 +46,9 @@ wr::MaterialHandle wmr::MaterialManager::GetDefaultMaterial() noexcept
 	return m_default_material_handle;
 }
 
-wr::MaterialHandle wmr::MaterialManager::CreateMaterial(MObject& fnmesh, MObject &shading_engine, MPlug &surface_shader)
+wr::MaterialHandle wmr::MaterialManager::CreateMaterial(MObject& mesh, MObject &shading_engine, MPlug &surface_shader)
 {
 	MStatus status;
-	MFnMesh mesh(fnmesh);
 
 	wr::MaterialHandle material_handle = ConnectShaderToShadingEngine(surface_shader, shading_engine);
 

--- a/src/plugin/renderer/material_manager.cpp
+++ b/src/plugin/renderer/material_manager.cpp
@@ -24,7 +24,7 @@ wmr::MaterialManager::MaterialManager() :
 wmr::MaterialManager::~MaterialManager()
 {
 	m_mesh_shading_relations.clear();
-	m_mesh_shading_relations.clear();
+	m_surface_shader_shading_relations.clear();
 }
 
 void wmr::MaterialManager::Initialize()

--- a/src/plugin/renderer/material_manager.hpp
+++ b/src/plugin/renderer/material_manager.hpp
@@ -19,6 +19,19 @@ namespace wmr
 {
 	class SceneGraphParser;
 
+	struct MeshShadingEngineRelation
+	{
+		MObject mesh; // MFnMesh
+		MObject shading_engine; // kShadingEngine
+	};
+
+	struct SurfaceShaderShadingEngineRelation
+	{
+		wr::MaterialHandle material_handle; // Wisp material handle
+		MPlug surface_shader; // kShader
+		std::vector<MObject> shading_engines; // kShadingEngine that this surface shader is connected to
+	};
+
 	class MaterialManager
 	{
 	public:
@@ -28,18 +41,29 @@ namespace wmr
 		void Initialize();
 
 		wr::MaterialHandle GetDefaultMaterial() noexcept;
-		wr::MaterialHandle CreateMaterial(MObject& object);
-		wr::MaterialHandle DoesExist(MObject& object);
+		wr::MaterialHandle CreateMaterial(MObject& fnmesh, MObject &shading_engine, MPlug &surface_shader);
+		wr::Material * GetWispMaterial(wr::MaterialHandle & material_handle);
 
-		wr::Material* GetMaterial(MObject& object);
-		wr::Material* GetMaterial(wr::MaterialHandle handle) noexcept;
+		// Returns a pointer to an element from a vector (storing this reference might, over time, be invalid)
+		SurfaceShaderShadingEngineRelation * DoesMaterialHandleExist(wr::MaterialHandle & material_handle);
+		// Returns a pointer to an element from a vector (storing this reference might, over time, be invalid)
+		SurfaceShaderShadingEngineRelation * DoesSurfaceShaderExist(MPlug & surface_shader);
+
 	private:
-		wmr::ScenegraphParser * m_scenegraph_parser;
 
-		std::vector<std::pair<MObject, wr::MaterialHandle>> m_object_material_vector;
+		void ApplyMaterialToModel(wr::MaterialHandle material_handle, MObject & fnmesh);
+
+		wmr::ScenegraphParser * m_scenegraph_parser;
 		
 		wr::MaterialHandle m_default_material_handle;
 		std::shared_ptr<wr::MaterialPool> m_material_pool;
+
+		// Relationship array of meshes and shading engines (shader groups)
+		// Don't need a struct if mesh can be extracted from a shading engine
+		std::vector<MeshShadingEngineRelation> m_mesh_shading_relations;
+		// Relationship array of surface shaders and shading engines (shader groups)
+		// A surface shader can be attached to multiple shading engines, so we need to keep track of these materials
+		std::vector<SurfaceShaderShadingEngineRelation> m_surface_shader_shading_relations;
 	};
 
 }

--- a/src/plugin/renderer/material_manager.hpp
+++ b/src/plugin/renderer/material_manager.hpp
@@ -62,7 +62,7 @@ namespace wmr
 
 		// Unbinds the shader and shading engine relationship. Removes the relationship entry if the relation was found.
 		// This doesn't bind the relationship between the shading engine and surface shader!
-		void DisconnectMeshFromShadingEngine(MFnMesh & fnmesh, MObject & shading_engine);
+		void DisconnectMeshFromShadingEngine(MFnMesh & fnmesh, MObject & shading_engine, bool reset_material = true);
 
 
 		wr::MaterialHandle GetDefaultMaterial() noexcept;
@@ -75,7 +75,10 @@ namespace wmr
 
 	private:
 		wmr::ScenegraphParser * GetSceneParser();
-		void ApplyMaterialToModel(wr::MaterialHandle material_handle, MObject & fnmesh);
+
+		wr::MaterialHandle FindWispMaterialByShadingEngine(MObject & shading_engine);
+
+		void ApplyMaterialToModel(wr::MaterialHandle& material_handle, MObject & fnmesh);
 
 		wmr::ScenegraphParser * m_scenegraph_parser;
 		

--- a/src/plugin/renderer/material_manager.hpp
+++ b/src/plugin/renderer/material_manager.hpp
@@ -43,7 +43,7 @@ namespace wmr
 		void Initialize();
 
 		// Creates a wisp material and bind all neccessary relationships
-		wr::MaterialHandle CreateMaterial(MObject& fnmesh, MObject &shading_engine, MPlug &surface_shader);
+		wr::MaterialHandle CreateMaterial(MObject& mesh, MObject &shading_engine, MPlug &surface_shader);
 
 		// Binds the surface shader and shading engine relationship. 
 		// Checks if shading engine is already bound: (true) remove connection and set new conn. (false) Set new conn

--- a/src/plugin/renderer/material_manager.hpp
+++ b/src/plugin/renderer/material_manager.hpp
@@ -42,7 +42,8 @@ namespace wmr
 
 		void Initialize();
 
-		void OnCreateSurfaceShader(MPlug & surface_shader);
+		// Returns a pointer to an element from a vector (storing this reference might, over time, be invalid)
+		SurfaceShaderShadingEngineRelation * OnCreateSurfaceShader(MPlug & surface_shader);
 		void OnRemoveSurfaceShader(MPlug & surface_shader);
 
 		// Creates a wisp material and bind all neccessary relationships

--- a/src/plugin/renderer/material_manager.hpp
+++ b/src/plugin/renderer/material_manager.hpp
@@ -42,6 +42,9 @@ namespace wmr
 
 		void Initialize();
 
+		void OnCreateSurfaceShader(MPlug & surface_shader);
+		void OnRemoveSurfaceShader(MPlug & surface_shader);
+
 		// Creates a wisp material and bind all neccessary relationships
 		wr::MaterialHandle CreateMaterial(MObject& mesh, MObject &shading_engine, MPlug &surface_shader);
 
@@ -71,9 +74,10 @@ namespace wmr
 		// Returns a pointer to an element from a vector (storing this reference might, over time, be invalid)
 		SurfaceShaderShadingEngineRelation * DoesShaderEngineExist(MObject & shading_engine);
 		// Returns a pointer to an element from a vector (storing this reference might, over time, be invalid)
-		SurfaceShaderShadingEngineRelation * DoesSurfaceShaderExist(MPlug & surface_shader);
+		SurfaceShaderShadingEngineRelation * DoesSurfaceShaderExist(MObject & surface_shader);
 
 		wr::MaterialHandle FindWispMaterialByShadingEngine(MObject & shading_engine);
+		wr::MaterialHandle FindWispMaterialBySurfaceShader(MObject & surface_shader);
 
 	private:
 		wmr::ScenegraphParser * GetSceneParser();

--- a/src/plugin/renderer/material_manager.hpp
+++ b/src/plugin/renderer/material_manager.hpp
@@ -45,7 +45,6 @@ namespace wmr
 		// Creates a wisp material and bind all neccessary relationships
 		wr::MaterialHandle CreateMaterial(MObject& fnmesh, MObject &shading_engine, MPlug &surface_shader);
 
-		
 		// Binds the surface shader and shading engine relationship. 
 		// Checks if shading engine is already bound: (true) remove connection and set new conn. (false) Set new conn
 		// This doesn't bind the relationship between the shading engine and surface shader!
@@ -58,12 +57,11 @@ namespace wmr
 		
 		// Binds the MFnMesh and shading engine relationship. Either replaces or adds an new relationship.
 		// This doesn't bind the relationship between the shading engine and surface shader!
-		void ConnectMeshToShadingEngine(MFnMesh & fnmesh, MObject & shading_engine);
+		void ConnectMeshToShadingEngine(MObject & mesh, MObject & shading_engine);
 
 		// Unbinds the shader and shading engine relationship. Removes the relationship entry if the relation was found.
 		// This doesn't bind the relationship between the shading engine and surface shader!
-		void DisconnectMeshFromShadingEngine(MFnMesh & fnmesh, MObject & shading_engine, bool reset_material = true);
-
+		void DisconnectMeshFromShadingEngine(MObject & mesh, MObject & shading_engine, bool reset_material = true);
 
 		wr::MaterialHandle GetDefaultMaterial() noexcept;
 		wr::Material * GetWispMaterial(wr::MaterialHandle & material_handle);

--- a/src/plugin/renderer/material_manager.hpp
+++ b/src/plugin/renderer/material_manager.hpp
@@ -69,12 +69,14 @@ namespace wmr
 		// Returns a pointer to an element from a vector (storing this reference might, over time, be invalid)
 		SurfaceShaderShadingEngineRelation * DoesMaterialHandleExist(wr::MaterialHandle & material_handle);
 		// Returns a pointer to an element from a vector (storing this reference might, over time, be invalid)
+		SurfaceShaderShadingEngineRelation * DoesShaderEngineExist(MObject & shading_engine);
+		// Returns a pointer to an element from a vector (storing this reference might, over time, be invalid)
 		SurfaceShaderShadingEngineRelation * DoesSurfaceShaderExist(MPlug & surface_shader);
+
+		wr::MaterialHandle FindWispMaterialByShadingEngine(MObject & shading_engine);
 
 	private:
 		wmr::ScenegraphParser * GetSceneParser();
-
-		wr::MaterialHandle FindWispMaterialByShadingEngine(MObject & shading_engine);
 
 		void ApplyMaterialToModel(wr::MaterialHandle& material_handle, MObject & fnmesh);
 

--- a/src/plugin/renderer/material_manager.hpp
+++ b/src/plugin/renderer/material_manager.hpp
@@ -61,7 +61,7 @@ namespace wmr
 		
 		// Binds the MFnMesh and shading engine relationship. Either replaces or adds an new relationship.
 		// This doesn't bind the relationship between the shading engine and surface shader!
-		void ConnectMeshToShadingEngine(MObject & mesh, MObject & shading_engine);
+		void ConnectMeshToShadingEngine(MObject & mesh, MObject & shading_engine, wr::MaterialHandle * material_handle = nullptr);
 
 		// Unbinds the shader and shading engine relationship. Removes the relationship entry if the relation was found.
 		// This doesn't bind the relationship between the shading engine and surface shader!

--- a/src/plugin/renderer/material_manager.hpp
+++ b/src/plugin/renderer/material_manager.hpp
@@ -54,7 +54,7 @@ namespace wmr
 		// Unbinds the surface shader and shading engine relationship. 
 		// Tries to find the surface shader and a shader engine in the relationships of that shader. Removes the shading engine from the bound shading engines
 		// This doesn't bind the relationship between the shading engine and surface shader!
-		void DisonnectShaderFromShadingEngine(MPlug & surface_shader, MObject & shading_engine);
+		void DisconnectShaderFromShadingEngine(MPlug & surface_shader, MObject & shading_engine);
 		
 		// Binds the MFnMesh and shading engine relationship. Either replaces or adds an new relationship.
 		// This doesn't bind the relationship between the shading engine and surface shader!

--- a/src/plugin/renderer/material_manager.hpp
+++ b/src/plugin/renderer/material_manager.hpp
@@ -52,7 +52,7 @@ namespace wmr
 		// Binds the surface shader and shading engine relationship. 
 		// Checks if shading engine is already bound: (true) remove connection and set new conn. (false) Set new conn
 		// This doesn't bind the relationship between the shading engine and surface shader!
-		wr::MaterialHandle ConnectShaderToShadingEngine(MPlug & surface_shader, MObject & shading_engine);
+		wr::MaterialHandle ConnectShaderToShadingEngine(MPlug & surface_shader, MObject & shading_engine, bool apply_material = false);
 
 		// Unbinds the surface shader and shading engine relationship. 
 		// Tries to find the surface shader and a shader engine in the relationships of that shader. Removes the shading engine from the bound shading engines

--- a/src/plugin/renderer/material_manager.hpp
+++ b/src/plugin/renderer/material_manager.hpp
@@ -17,7 +17,7 @@ namespace wr
 
 namespace wmr
 {
-	class SceneGraphParser;
+	class ScenegraphParser;
 
 	struct MeshShadingEngineRelation
 	{
@@ -30,6 +30,8 @@ namespace wmr
 		wr::MaterialHandle material_handle; // Wisp material handle
 		MPlug surface_shader; // kShader
 		std::vector<MObject> shading_engines; // kShadingEngine that this surface shader is connected to
+
+		std::vector<MObject>::iterator FindShadingEngine(MObject & shading_engine);
 	};
 
 	class MaterialManager
@@ -40,8 +42,30 @@ namespace wmr
 
 		void Initialize();
 
-		wr::MaterialHandle GetDefaultMaterial() noexcept;
+		// Creates a wisp material and bind all neccessary relationships
 		wr::MaterialHandle CreateMaterial(MObject& fnmesh, MObject &shading_engine, MPlug &surface_shader);
+
+		
+		// Binds the surface shader and shading engine relationship. 
+		// Checks if shading engine is already bound: (true) remove connection and set new conn. (false) Set new conn
+		// This doesn't bind the relationship between the shading engine and surface shader!
+		wr::MaterialHandle ConnectShaderToShadingEngine(MPlug & surface_shader, MObject & shading_engine);
+
+		// Unbinds the surface shader and shading engine relationship. 
+		// Tries to find the surface shader and a shader engine in the relationships of that shader. Removes the shading engine from the bound shading engines
+		// This doesn't bind the relationship between the shading engine and surface shader!
+		void DisonnectShaderFromShadingEngine(MPlug & surface_shader, MObject & shading_engine);
+		
+		// Binds the MFnMesh and shading engine relationship. Either replaces or adds an new relationship.
+		// This doesn't bind the relationship between the shading engine and surface shader!
+		void ConnectMeshToShadingEngine(MFnMesh & fnmesh, MObject & shading_engine);
+
+		// Unbinds the shader and shading engine relationship. Removes the relationship entry if the relation was found.
+		// This doesn't bind the relationship between the shading engine and surface shader!
+		void DisconnectMeshFromShadingEngine(MFnMesh & fnmesh, MObject & shading_engine);
+
+
+		wr::MaterialHandle GetDefaultMaterial() noexcept;
 		wr::Material * GetWispMaterial(wr::MaterialHandle & material_handle);
 
 		// Returns a pointer to an element from a vector (storing this reference might, over time, be invalid)
@@ -50,7 +74,7 @@ namespace wmr
 		SurfaceShaderShadingEngineRelation * DoesSurfaceShaderExist(MPlug & surface_shader);
 
 	private:
-
+		wmr::ScenegraphParser * GetSceneParser();
 		void ApplyMaterialToModel(wr::MaterialHandle material_handle, MObject & fnmesh);
 
 		wmr::ScenegraphParser * m_scenegraph_parser;


### PR DESCRIPTION
## Description
Improved the material parser that parses materials from Maya to Wisp. It still requires some adjustments and improvements, but it's in a stable state right now.

When importing models, make sure you're in the Maya default viewport and render with textures to make sure that textures are properly bound. The texture and material changes aren't completely implemented, yet, as that isn't related to this task.

## Motivation and Context
The material parser wasn't implemented well yet and required a bit more work and research. There will be some issues made for this PR (issues will be linked below).

## How Has This Been Tested?
It has been tested with the vault (as can be seen in the video) and some simple shapes with lambert materials. The texture and material changes aren't completely implemented, yet, as that isn't related to this task.

The PR affects some code from the model parser, scene graph parser and texture manager.

## Screenshots (if appropriate):
[Link to video](https://www.dropbox.com/s/2u6il7ppxbnsa0p/2019-04-01_15-37-44.mp4?dl=0)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
