### PR TITLE
Feature framegraph resizing

### DIFF
--- a/module/wisp/scripts/switch_rendering_pipeline.mel
+++ b/module/wisp/scripts/switch_rendering_pipeline.mel
@@ -1,17 +1,16 @@
-global proc optionMenuChanged()
+global proc switch_rendering_pipeline()
 {
-    int $selectedItem = `optionMenu -q -sl ChangeWispRenderingPipeline`;
-    
-    if (`exists "wisp_switch_rendering_pipeline"`)
+    if(`menu -exists Wisp`)
     {
-        wisp_switch_rendering_pipeline ($selectedItem - 1);
+        deleteUI Wisp;
     }
-}
 
-window;
-	columnLayout;
-	    optionMenu -label "Rendering Pipeline Type" -cc optionMenuChanged ChangeWispRenderingPipeline;
-            menuItem -label "Deferred";
-            menuItem -label "Hybrid Ray-Tracing";
-            menuItem -label "Full Ray-Tracing";
-showWindow;
+    global string $gMainWindow;
+    setParent($gMainWindow);
+    
+    menu -label "Wisp" -to true -aob true Wisp;
+        menuItem -label "Deferred Pipeline" -command "wisp_switch_rendering_pipeline(\"-deferred\")";
+        menuItem -label "Hybrid Ray-Tracing Pipeline" -command "wisp_switch_rendering_pipeline(\"-hybrid_ray_trace\")";
+        menuItem -label "Full Ray-Tracing Pipeline" -command "wisp_switch_rendering_pipeline(\"-full_ray_trace\")";
+        menuItem -label "Path-Tracing Pipeline" -command "wisp_switch_rendering_pipeline(\"-path_trace\")";
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -75,7 +75,10 @@ MStatus initializePlugin(MObject object)
 	MFnPlugin plugin(object, wmr::settings::COMPANY_NAME, wmr::settings::PRODUCT_VERSION, "Any");
 
 	// Register the command that enabled a MEL script to switch rendering pipelines
-	plugin.registerCommand(wmr::settings::RENDER_PIPELINE_SELECT_COMMAND_NAME, wmr::RenderPipelineSelectCommand::creator);
+	plugin.registerCommand(wmr::settings::RENDER_PIPELINE_SELECT_COMMAND_NAME, wmr::RenderPipelineSelectCommand::creator, wmr::RenderPipelineSelectCommand::create_syntax);
+
+	// Add the Wisp UI to the menu bar in Maya
+	MGlobal::executeCommand("switch_rendering_pipeline");
 
 	// Workaround for avoiding dirtying the scene when registering overrides
 	const auto is_scene_dirty = IsSceneDirty();

--- a/src/plugin/framegraph/frame_graph_manager.cpp
+++ b/src/plugin/framegraph/frame_graph_manager.cpp
@@ -17,6 +17,8 @@
 #include "render_tasks/d3d12_post_processing.hpp"
 #include "render_tasks/d3d12_raytracing_task.hpp"
 #include "render_tasks/d3d12_rt_hybrid_task.hpp"
+#include "render_tasks/d3d12_path_tracer.hpp"
+#include "render_tasks/d3d12_accumulation.hpp"
 
 namespace wmr
 {
@@ -42,6 +44,7 @@ namespace wmr
 		CreateDeferredPipeline();
 		CreateHybridRTPipeline();
 		CreateFullRTPipeline();
+		CreatePathTracerPipeline();
 
 		// Set-up the rendering pipelines (frame graph configuration)
 		for (auto& frame_graph : m_renderer_frame_graphs)
@@ -65,6 +68,12 @@ namespace wmr
 		m_width = new_width;
 		m_height = new_height;
 
+		// Wait until the GPU is done executing
+		render_system.WaitForAllPreviousWork();
+
+		// Resize the renderer viewport
+		render_system.Resize(new_width, new_height);
+
 		m_renderer_frame_graphs[static_cast<size_t>(m_current_rendering_pipeline_type)]->Resize(render_system, new_width, new_height);
 	}
 
@@ -78,7 +87,9 @@ namespace wmr
 		auto frame_graph = new wr::FrameGraph(9);
 
 		// Precalculate BRDF Lut
-		wr::AddBrdfLutPrecalculationTask( *frame_graph );
+		wr::AddBrdfLutPrecalculationTask(*frame_graph);
+
+		// Skybox
 		wr::AddEquirectToCubemapTask(*frame_graph);
 		wr::AddCubemapConvolutionTask(*frame_graph);
 
@@ -106,14 +117,15 @@ namespace wmr
 
 	void FrameGraphManager::CreateHybridRTPipeline() noexcept
 	{
-		auto frame_graph = new wr::FrameGraph(7);
+		auto frame_graph = new wr::FrameGraph(10);
 
 		// Precalculate BRDF Lut
-		wr::AddBrdfLutPrecalculationTask(*frame_graph);
-
 		wr::AddBrdfLutPrecalculationTask( *frame_graph );
+		
+		// Skybox
 		wr::AddEquirectToCubemapTask( *frame_graph );
 		wr::AddCubemapConvolutionTask( *frame_graph );
+
 		// Construct the G-buffer
 		wr::AddDeferredMainTask(*frame_graph, std::nullopt, std::nullopt);
 
@@ -141,9 +153,9 @@ namespace wmr
 
 	void FrameGraphManager::CreateFullRTPipeline() noexcept
 	{
-		auto frame_graph = new wr::FrameGraph(4);
+		auto frame_graph = new wr::FrameGraph(5);
 
-		// Construct the acceleraion structures needed for the ray tracing task
+		// Construct the acceleration structures needed for the ray tracing task
 		wr::AddBuildAccelerationStructuresTask(*frame_graph);
 
 		// Perform ray tracing
@@ -160,5 +172,43 @@ namespace wmr
 
 		// Store the frame graph for future use
 		m_renderer_frame_graphs[static_cast<size_t>(RendererFrameGraphType::FULL_RAY_TRACING)] = frame_graph;
+	}
+
+	void FrameGraphManager::CreatePathTracerPipeline() noexcept
+	{
+		auto frame_graph = new wr::FrameGraph(10);
+
+		// Precalculate BRDF Lut
+		wr::AddBrdfLutPrecalculationTask(*frame_graph);
+
+		// Skybox
+		wr::AddEquirectToCubemapTask(*frame_graph);
+		wr::AddCubemapConvolutionTask(*frame_graph);
+
+		// Construct the G-buffer
+		wr::AddDeferredMainTask(*frame_graph, std::nullopt, std::nullopt);
+
+		// Build Acceleration Structure
+		wr::AddBuildAccelerationStructuresTask(*frame_graph);
+
+		// Raytracing task
+		//wr::AddRTHybridTask(*fg);
+
+		// Global Illumination Path Tracing
+		wr::AddPathTracerTask(*frame_graph);
+		wr::AddAccumulationTask<wr::PathTracerData>(*frame_graph);
+
+		wr::AddDeferredCompositionTask(*frame_graph, std::nullopt, std::nullopt);
+
+		// Do some post processing
+		wr::AddPostProcessingTask<wr::DeferredCompositionTaskData>(*frame_graph);
+
+		// Save the path tracing pixel data CPU pointer
+		wr::AddPixelDataReadBackTask<wr::PostProcessingData>(*frame_graph, std::nullopt, std::nullopt);
+
+		// Copy the raytracing pixel data to the final render target
+		wr::AddRenderTargetCopyTask<wr::PostProcessingData>(*frame_graph);
+
+		m_renderer_frame_graphs[static_cast<size_t>(RendererFrameGraphType::PATH_TRACER)] = frame_graph;
 	}
 }

--- a/src/plugin/framegraph/frame_graph_manager.cpp
+++ b/src/plugin/framegraph/frame_graph_manager.cpp
@@ -117,7 +117,7 @@ namespace wmr
 
 	void FrameGraphManager::CreateHybridRTPipeline() noexcept
 	{
-		auto frame_graph = new wr::FrameGraph(10);
+		auto frame_graph = new wr::FrameGraph(11);
 
 		// Precalculate BRDF Lut
 		wr::AddBrdfLutPrecalculationTask( *frame_graph );
@@ -138,8 +138,10 @@ namespace wmr
 		// Ray tracing
 		wr::AddRTHybridTask(*frame_graph);
 
+		wr::AddDeferredCompositionTask(*frame_graph, std::nullopt, std::nullopt);
+
 		// Do some post processing
-		wr::AddPostProcessingTask<wr::RTHybridData>(*frame_graph);
+		wr::AddPostProcessingTask<wr::DeferredCompositionTaskData>(*frame_graph);
 
 		// Save the ray tracing pixel data CPU pointer
 		wr::AddPixelDataReadBackTask<wr::PostProcessingData>(*frame_graph, std::nullopt, std::nullopt);

--- a/src/plugin/framegraph/frame_graph_manager.cpp
+++ b/src/plugin/framegraph/frame_graph_manager.cpp
@@ -155,10 +155,14 @@ namespace wmr
 
 	void FrameGraphManager::CreateFullRTPipeline() noexcept
 	{
-		auto frame_graph = new wr::FrameGraph(5);
+		auto frame_graph = new wr::FrameGraph(7);
 
 		// Construct the acceleration structures needed for the ray tracing task
 		wr::AddBuildAccelerationStructuresTask(*frame_graph);
+
+		// Skybox
+		wr::AddEquirectToCubemapTask(*frame_graph);
+		wr::AddCubemapConvolutionTask(*frame_graph);
 
 		// Perform ray tracing
 		wr::AddRaytracingTask(*frame_graph);

--- a/src/plugin/framegraph/frame_graph_manager.cpp
+++ b/src/plugin/framegraph/frame_graph_manager.cpp
@@ -74,7 +74,11 @@ namespace wmr
 		// Resize the renderer viewport
 		render_system.Resize(new_width, new_height);
 
-		m_renderer_frame_graphs[static_cast<size_t>(m_current_rendering_pipeline_type)]->Resize(render_system, new_width, new_height);
+		// Resize all framegraphs
+		for (auto& frame_graph : m_renderer_frame_graphs)
+		{
+			frame_graph->Resize(render_system, new_width, new_height);
+		}
 	}
 
 	std::pair<std::uint32_t, std::uint32_t> FrameGraphManager::GetCurrentDimensions() const noexcept

--- a/src/plugin/framegraph/frame_graph_manager.hpp
+++ b/src/plugin/framegraph/frame_graph_manager.hpp
@@ -21,6 +21,7 @@ namespace wmr
 		DEFERRED = 0,					/*!< Only use the basic deferred rendering pipeline. */
 		HYBRID_RAY_TRACING,				/*!< Combine deferred rendering and ray tracing to render the scene. */
 		FULL_RAY_TRACING,				/*!< Only use ray tracing to render the scene. */
+		PATH_TRACER,					/*!< Generate a 100% path traced. */
 
 		RENDERING_PIPELINE_TYPE_COUNT	/*!< Total number of rendering frame graph types available. */
 	};
@@ -77,6 +78,9 @@ namespace wmr
 
 		//! Configure a frame graph for a full ray traced rendering pipeline
 		void CreateFullRTPipeline() noexcept;
+
+		//! Configure a frame graph for a full path traced rendering pipeline
+		void CreatePathTracerPipeline() noexcept;
 
 	private:
 		std::uint32_t m_width;										//! Width of the render texture

--- a/src/plugin/renderer/render_pipeline_select_command.cpp
+++ b/src/plugin/renderer/render_pipeline_select_command.cpp
@@ -7,44 +7,73 @@
 
 // Maya API
 #include <maya/MArgList.h>
+#include <maya/MArgParser.h>
+#include <maya/MSyntax.h>
 #include <maya/MViewport2Renderer.h>
 
 MStatus wmr::RenderPipelineSelectCommand::doIt(const MArgList& args)
 {
-	// Get the frame graph in the renderer
-	FrameGraphManager& frame_graph = dynamic_cast<const ViewportRendererOverride*>(MHWRender::MRenderer::theRenderer()->findRenderOverride(settings::VIEWPORT_OVERRIDE_NAME))->GetRenderer().GetFrameGraph();
+	MStatus status;
 
-	// Invalid number of arguments
-	if (args.length() != 1)
+	MArgParser arg_data(syntax(), args, &status);
+
+	// Get the frame graph in the renderer
+	auto viewport_override = dynamic_cast<const ViewportRendererOverride*>(MHWRender::MRenderer::theRenderer()->findRenderOverride(settings::VIEWPORT_OVERRIDE_NAME));
+
+	// The viewport override has not been initialized properly yet
+	if (!viewport_override->IsInitialized())
 		return MStatus::kFailure;
 
-	// Arguments:
-	//  0 -> deferred
-	//  1 -> hybrid ray-tracing
-	//  2 -> full ray-tracing
-	auto arg = args.asInt(0);
+	auto& renderer = viewport_override->GetRenderer();
+	auto& frame_graph = renderer.GetFrameGraph();
 
-	switch (arg)
+	bool deferred_set = arg_data.isFlagSet("deferred");
+	bool hybrid_set = arg_data.isFlagSet("hybrid_ray_trace");
+	bool full_rt_set = arg_data.isFlagSet("full_ray_trace");
+	bool path_trace_set = arg_data.isFlagSet("path_trace");
+
+	// Viewport dimensions are needed to force the resizing of the frame graph after switching rendering pipeline
+	auto viewport_dimensions = viewport_override->GetViewportSize();
+
+	if (deferred_set)
 	{
-		// Deferred
-		case 0:
-			frame_graph.SetType(RendererFrameGraphType::DEFERRED);
-			break;
-
-		// Hybrid ray-tracing
-		case 1:
-			frame_graph.SetType(RendererFrameGraphType::HYBRID_RAY_TRACING);
-			break;
-
-		// Full ray-tracing
-		case 2:
-			frame_graph.SetType(RendererFrameGraphType::FULL_RAY_TRACING);
-			break;
-
-		// Invalid argument
-		default:
-			break;
+		frame_graph.SetType(RendererFrameGraphType::DEFERRED);
+	}
+	else if (hybrid_set)
+	{
+		frame_graph.SetType(RendererFrameGraphType::HYBRID_RAY_TRACING);
+	}
+	else if (full_rt_set)
+	{
+		frame_graph.SetType(RendererFrameGraphType::FULL_RAY_TRACING);
+	}
+	else if (path_trace_set)
+	{
+		frame_graph.SetType(RendererFrameGraphType::PATH_TRACER);
+	}
+	else
+	{
+		// Invalid
+		return MStatus::kFailure;
 	}
 
+	// Force resize of the current frame graph
+	frame_graph.Resize(viewport_dimensions.first, viewport_dimensions.second, renderer.GetD3D12Renderer());
+
 	return MStatus::kSuccess;
+}
+
+MSyntax wmr::RenderPipelineSelectCommand::create_syntax()
+{
+	MSyntax syntax;
+
+	syntax.addFlag("-d", "-deferred",			MSyntax::kNoArg);
+	syntax.addFlag("-h", "-hybrid_ray_trace",	MSyntax::kNoArg);
+	syntax.addFlag("-f", "-full_ray_trace",		MSyntax::kNoArg);
+	syntax.addFlag("-p", "-path_trace",			MSyntax::kNoArg);
+
+	syntax.enableQuery(false);
+	syntax.enableEdit(false);
+
+	return syntax;
 }

--- a/src/plugin/renderer/render_pipeline_select_command.cpp
+++ b/src/plugin/renderer/render_pipeline_select_command.cpp
@@ -32,9 +32,6 @@ MStatus wmr::RenderPipelineSelectCommand::doIt(const MArgList& args)
 	bool full_rt_set = arg_data.isFlagSet("full_ray_trace");
 	bool path_trace_set = arg_data.isFlagSet("path_trace");
 
-	// Viewport dimensions are needed to force the resizing of the frame graph after switching rendering pipeline
-	auto viewport_dimensions = viewport_override->GetViewportSize();
-
 	if (deferred_set)
 	{
 		frame_graph.SetType(RendererFrameGraphType::DEFERRED);
@@ -56,9 +53,6 @@ MStatus wmr::RenderPipelineSelectCommand::doIt(const MArgList& args)
 		// Invalid
 		return MStatus::kFailure;
 	}
-
-	// Force resize of the current frame graph
-	frame_graph.Resize(viewport_dimensions.first, viewport_dimensions.second, renderer.GetD3D12Renderer());
 
 	return MStatus::kSuccess;
 }

--- a/src/plugin/renderer/render_pipeline_select_command.hpp
+++ b/src/plugin/renderer/render_pipeline_select_command.hpp
@@ -18,5 +18,6 @@ namespace wmr
 		MStatus undoIt() override { return MStatus::kSuccess; }
 		bool isUndoable() const override { return false; };
 		static void* creator() { return new RenderPipelineSelectCommand(); }
+		static MSyntax create_syntax();
 	};
 }

--- a/src/plugin/viewport_renderer_override.hpp
+++ b/src/plugin/viewport_renderer_override.hpp
@@ -76,6 +76,12 @@ namespace wmr
 		/*! /return SceneGraphParser reference. */
 		wmr::ScenegraphParser& GetSceneGraphParser() const;
 
+		//! Get the viewport width and height
+		const std::pair<uint32_t, uint32_t> GetViewportSize() const noexcept;
+
+		//! Lets the caller know when the plug-in has completed at least a single setup loop
+		bool IsInitialized() const noexcept;
+
 	private:
 		//! Assign the correct render operations to the render operation container
 		/*! The names specified by the ConfigureRenderOperations() function indicate the order in which the render
@@ -142,5 +148,10 @@ namespace wmr
 
 		std::unique_ptr<Renderer> m_renderer; //!< Wisp framework render system
 		std::unique_ptr<wmr::ScenegraphParser> m_scenegraph_parser;
+
+		uint32_t m_viewport_width;
+		uint32_t m_viewport_height;
+
+		bool m_is_initialized;
 	};
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
I "fixed" the Hybrid frame graph. It now displays textures somewhat correctly. Reflections look really bad, though. 🤷‍♂️ 

## Description
- Frame graphs now properly resize.
- Maya MEL UI can be used to switch frame graphs.
- Fixed the hybrid pipeline.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- We need RTX ON.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I tried it on the RTX machine. Showed it to others as well. 

## Screenshots (if appropriate):
The RTX machine is occupied, but trust me, it works.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

## Relevant:
- #45