### PR TITLE
Depth buffer issue (hack)

### DIFF
--- a/module/wisp/bin/wispBlitColorDepth.ogsfx
+++ b/module/wisp/bin/wispBlitColorDepth.ogsfx
@@ -57,8 +57,9 @@ GLSLShader PS_BlitColorDepth
 
 		// Output depth
 		//
-		vec4 depth = texture2D(gDepthSampler, uv); 
-		gl_FragDepth = depth.r;
+		vec4 depth = texture2D(gDepthSampler, uv);
+		float depthScalar = 1.0 - (depth.r * ((1.0 - depth.r) * 0.5));
+		gl_FragDepth = depthScalar;
 	}
 }
 


### PR DESCRIPTION
The depth buffer is in a better state than it was before (see images below). The fix is a hack and NOT a valid solution. However, it fixes the extreme errors that were there.

This PR is relevant to issue #33 
I've added an additional comment there to describe the 'fix' that I've implemented.

**The Maya viewport next to the 'fixed' Wisp viewport**
[![The Maya viewport next to the 'fixed' Wisp viewport](https://gyazo.com/9da503ff20d19df6b94d4dafb9a6d126/raw)](https://gyazo.com/9da503ff20d19df6b94d4dafb9a6d126)

**Zoomed in on tiny errors that are still there**
[![Zoomed in on tiny errors that are still there](https://gyazo.com/64e8295f997d6386c15d2a016043872b/raw)](https://gyazo.com/64e8295f997d6386c15d2a016043872b)

**Zoomed in on tiny errors that are still there**
[![Zoomed in on tiny errors that are still there](https://gyazo.com/47c05995db83b10c17ceaf18363e44ac/raw)](https://gyazo.com/47c05995db83b10c17ceaf18363e44ac)