### PR TITLE
Fix for boolean functions in Maya

### DIFF
--- a/src/plugin/parsers/model_parser.cpp
+++ b/src/plugin/parsers/model_parser.cpp
@@ -402,7 +402,8 @@ namespace wmr
 			return;
 		}
 
-		wmr::ModelParser* model_parser = reinterpret_cast< wmr::ModelParser* >( client_data );
+		wmr::ModelParser* model_parser = reinterpret_cast<wmr::ModelParser*>(client_data);
+
 		// Add the mesh
 		model_parser->MeshAdded(mesh);
 
@@ -426,7 +427,8 @@ namespace wmr
 
 		if (model_parser->m_mesh_added_callback_vector.size() <= 0)
 		{
-			LOGC("Mesh added callback vector size is zero.");
+			LOGW("Mesh added callback vector size is zero.");
+			return;
 		}
 
 		auto it_end = --model_parser->m_mesh_added_callback_vector.end();
@@ -558,7 +560,7 @@ void wmr::ModelParser::UnSubscribeObject( MObject & maya_object )
 
 }
 
-void wmr::ModelParser::MeshAdded( MFnMesh & fnmesh )
+bool wmr::ModelParser::MeshAdded( MFnMesh & fnmesh )
 {
 	wr::MeshData<wr::Vertex> mesh_data;
 	
@@ -592,8 +594,27 @@ void wmr::ModelParser::MeshAdded( MFnMesh & fnmesh )
 
 	updateTransform( transform, model_node );
 
-	m_object_transform_vector.push_back( std::make_pair( fnmesh.object(), model_node ) );
+	// Check if the mesh is already added
+	MObject mesh_object = fnmesh.object();
+	auto itt = std::find_if(m_object_transform_vector.begin(), m_object_transform_vector.end(), getMeshObjectAlgorithm(mesh_object));
+	if (itt != m_object_transform_vector.end())
+	{
+		// If it is, still add it to mesh changed vector
+		auto changed_itt = std::find(m_changed_mesh_vector.begin(), m_changed_mesh_vector.end(), mesh_object);
+		if (changed_itt == m_changed_mesh_vector.end())
+		{
+			m_changed_mesh_vector.push_back(mesh_object);
+		}
+		
+		// If the model is already in the vector, assume that it should be overwritten
+		// First remove it, then replace it
+		m_renderer.GetScenegraph().DestroyNode<wr::MeshNode>(itt->second);
+		itt->second = model_node;
 
+		// False, if the model HAS NOT been ADDED
+		return false;
+	}
+	m_object_transform_vector.push_back( std::make_pair(mesh_object, model_node ) );
 
 	MCallbackId attributeId = MNodeMessage::addAttributeChangedCallback(
 		object,
@@ -614,6 +635,8 @@ void wmr::ModelParser::MeshAdded( MFnMesh & fnmesh )
 	CallbackManager::GetInstance().RegisterCallback( attributeId );
 
 	LOG("Mesh \"{}\" added.", fnmesh.fullPathName().asChar());
+	// True, if the model HAS been ADDED
+	return true;
 }
 
 void wmr::ModelParser::Update()

--- a/src/plugin/parsers/model_parser.cpp
+++ b/src/plugin/parsers/model_parser.cpp
@@ -560,7 +560,7 @@ void wmr::ModelParser::UnSubscribeObject( MObject & maya_object )
 
 }
 
-bool wmr::ModelParser::MeshAdded( MFnMesh & fnmesh )
+void wmr::ModelParser::MeshAdded( MFnMesh & fnmesh )
 {
 	wr::MeshData<wr::Vertex> mesh_data;
 	
@@ -610,9 +610,6 @@ bool wmr::ModelParser::MeshAdded( MFnMesh & fnmesh )
 		// First remove it, then replace it
 		m_renderer.GetScenegraph().DestroyNode<wr::MeshNode>(itt->second);
 		itt->second = model_node;
-
-		// False, if the model HAS NOT been ADDED
-		return false;
 	}
 	m_object_transform_vector.push_back( std::make_pair(mesh_object, model_node ) );
 
@@ -635,8 +632,6 @@ bool wmr::ModelParser::MeshAdded( MFnMesh & fnmesh )
 	CallbackManager::GetInstance().RegisterCallback( attributeId );
 
 	LOG("Mesh \"{}\" added.", fnmesh.fullPathName().asChar());
-	// True, if the model HAS been ADDED
-	return true;
 }
 
 void wmr::ModelParser::Update()

--- a/src/plugin/parsers/model_parser.hpp
+++ b/src/plugin/parsers/model_parser.hpp
@@ -25,7 +25,7 @@ namespace wmr
 
 		void SubscribeObject( MObject& maya_object );
 		void UnSubscribeObject( MObject& maya_object );
-		bool MeshAdded( MFnMesh & fnmesh );
+		void MeshAdded( MFnMesh & fnmesh );
 		std::shared_ptr<wr::MeshNode> GetWRModel(MObject & maya_object);
 
 		void Update();

--- a/src/plugin/parsers/model_parser.hpp
+++ b/src/plugin/parsers/model_parser.hpp
@@ -25,7 +25,7 @@ namespace wmr
 
 		void SubscribeObject( MObject& maya_object );
 		void UnSubscribeObject( MObject& maya_object );
-		void MeshAdded( MFnMesh & fnmesh );
+		bool MeshAdded( MFnMesh & fnmesh );
 		std::shared_ptr<wr::MeshNode> GetWRModel(MObject & maya_object);
 
 		void Update();


### PR DESCRIPTION
This PR contains the changes to fix crashes when applying boolean functions on meshes.

## Description
When using a boolean function to combine two meshes, it used to crash because of invalid wisp models that are being created and added to the list.
This fix is done by checking if the mesh is already in the vector. If it is, the mesh replaces the current mesh in the vector and deletes the old mesh. We assume that Maya returns us the correct model as the last model, which seems to be the case. Also, the model is added to the 'changed model'-vector if it isn't in there yet.

## How Has This Been Tested?
Two meshes were created. A cube and a cone. Then, each boolean function is applied to these (on by one).

## Screenshots (if appropriate):
![Intersection operator (in Wisp viewport) leaving ghostmodel](https://user-images.githubusercontent.com/18393968/58248687-13da1280-7d5d-11e9-90b5-c47dc4063f3c.png)
**Intersection operator (in Wisp viewport) leaving ghostmodel**

![Intersection operator (in Maya viewport)](https://user-images.githubusercontent.com/18393968/58248759-43891a80-7d5d-11e9-8951-f04e0a6dd1bd.png)
**Intersection operator (in Maya viewport)**

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
