### PR TITLE
Fix ghost models

### DIFF
--- a/src/plugin/framegraph/frame_graph_manager.cpp
+++ b/src/plugin/framegraph/frame_graph_manager.cpp
@@ -184,11 +184,6 @@ namespace wmr
 		wr::AddBloomVerticalTask<wr::BloomHData>(*fg);
 		LOG("Added Depth of Field task.");
 
-		// Do some post processing//initialize default settings
-		wr::BloomSettings defaultSettings;
-		fg->UpdateSettings<wr::BloomSettings>(defaultSettings);
-		LOG("Updated bloom settings.");
-
 		wr::AddBloomCompositionTask<wr::DoFCompositionData, wr::BloomVData>(*fg);
 		LOG("Added bloom task.");
 
@@ -255,11 +250,6 @@ namespace wmr
 		wr::AddBloomHorizontalTask<wr::DownScaleData>(*fg);
 		wr::AddBloomVerticalTask<wr::BloomHData>(*fg);
 		LOG("Added Depth of Field task.");
-
-		//initialize default settings
-		wr::BloomSettings defaultSettings;
-		fg->UpdateSettings<wr::BloomSettings>(defaultSettings);
-		LOG("Updated bloom settings.");
 
 		wr::AddBloomCompositionTask<wr::DoFCompositionData, wr::BloomVData>(*fg);
 		LOG("Added bloom task.");

--- a/src/plugin/parsers/model_parser.cpp
+++ b/src/plugin/parsers/model_parser.cpp
@@ -606,7 +606,9 @@ void wmr::ModelParser::MeshAdded( MFnMesh & fnmesh )
 		m_renderer.GetScenegraph().DestroyNode<wr::MeshNode>(itt->second);
 		itt->second = model_node;
 	}
-	m_object_transform_vector.push_back( std::make_pair(mesh_object, model_node ) );
+	else {
+		m_object_transform_vector.push_back(std::make_pair(mesh_object, model_node));
+	}
 
 	MCallbackId attributeId = MNodeMessage::addAttributeChangedCallback(
 		object,

--- a/src/plugin/parsers/model_parser.cpp
+++ b/src/plugin/parsers/model_parser.cpp
@@ -497,8 +497,6 @@ wmr::ModelParser::ModelParser() :
 
 wmr::ModelParser::~ModelParser()
 {
-	m_object_transform_vector.clear();
-	m_hidden_meshes.clear();
 }
 
 void wmr::ModelParser::SubscribeObject( MObject & maya_object )
@@ -666,76 +664,37 @@ void wmr::ModelParser::SetMeshAddCallback(std::function<void(MFnMesh&)> callback
 	mesh_add_callback = callback;
 }
 
-void wmr::ModelParser::ShowMesh(MPlug & plug_mesh)
+void wmr::ModelParser::ToggleMeshVisibility(MPlug & plug_mesh, bool hide)
 {
 	// Check if the given plug is indeed a mesh object
 	MStatus status;
 	MFnMesh mesh = MFnMesh(plug_mesh.node(), &status);
 	if (status != MS::kSuccess) {
-		LOGW("Couldn't show mesh, as the given plug isn't a mesh!");
+		if (hide) {
+			LOGW("Couldn't hide mesh, as the given plug isn't a mesh!");
+		}
+		else {
+			LOGW("Couldn't show mesh, as the given plug isn't a mesh!");
+		}
 		return;
 	}
-	
-	// Check if the mesh is not in the hidden meshes array
-	// That means that the mesh is already shown.
+
 	MObject mesh_object = mesh.object();
-	auto itt_hidden = std::find_if(m_hidden_meshes.begin(), m_hidden_meshes.end(), getMeshObjectAlgorithm(mesh_object));
-	if (itt_hidden == m_hidden_meshes.end()) {
-		// This can happen a lot since transforms of meshes are often connected through the type kMesh
-		// So, a normal log is pushed
-		LOG("Couldn't show mesh, as the given mesh is already shown");
-		return;
-	}
-
-	// Get the itt of the given mesh object (from the standard meshes array)
-	auto itt_mesh = std::find_if(m_object_transform_vector.begin(), m_object_transform_vector.end(), getMeshObjectAlgorithm(mesh_object));
-	if (itt_mesh != m_object_transform_vector.end()) {
-		LOG("The mesh is already in the standard meshes array ((m_object_transform_vector). Can't show the same mesh again.");
-		return;
-	}
-
-	// Add mesh-wr::Mesh relationship back to standard meshes array
-	m_object_transform_vector.push_back(*itt_hidden);
-	// Remove mesh from hidden meshes array and add it to the wisp scenegraph again
-}
-
-void wmr::ModelParser::HideMesh(MPlug & plug_mesh)
-{
-	// Check if the given plug is indeed a mesh object
-	MStatus status;
-	MFnMesh mesh = MFnMesh(plug_mesh.node(), &status);
-	if (status != MS::kSuccess) {
-		LOGW("Couldn't hide mesh, as the given plug isn't a mesh!");
-		return;
-	}
-
-	// Check if the mesh is in the hidden meshes array
-	// That means that the mesh is already hidden.
-	MObject mesh_object = mesh.object();
-	auto itt_hidden = std::find_if(m_hidden_meshes.begin(), m_hidden_meshes.end(), getMeshObjectAlgorithm(mesh_object));
-	if (itt_hidden != m_hidden_meshes.end()) {
-		// This can happen a lot since transforms of meshes are often connected through the type kMesh
-		// So, a normal log is pushed
-		LOG("Couldn't hide mesh, as the given mesh is already hidden");
-		return;
-	}
 
 	// Get the itt of the given mesh object (from the standard meshes array)
 	auto itt_mesh = std::find_if(m_object_transform_vector.begin(), m_object_transform_vector.end(), getMeshObjectAlgorithm(mesh_object));
 	if (itt_mesh == m_object_transform_vector.end()) {
-		LOGE("Can't find the mesh to hide in the standard meshes array! (m_object_transform_vector)");
+		if (hide) {
+			LOG("Can't find the mesh to hide!");
+		}
+		else {
+			LOG("Can't find the mesh to show!");
+		}
 		return;
 	}
 
-	// Add mesh-wr::Mesh relationship to hidden array
-	m_hidden_meshes.push_back(*itt_mesh);
-	// Remove mesh from standard meshes array and remove it from the wisp scenegraph
-	if (itt_mesh != --m_object_transform_vector.end()) {
-		std::iter_swap(itt_mesh, --m_object_transform_vector.end());
-	}
-	m_object_transform_vector.pop_back();
-	// Get last added hidden mesh and delete it from the scenegraph
-	m_renderer.GetScenegraph().DestroyNode(m_hidden_meshes[m_hidden_meshes.size() - 1].second);
+	// Hide/show the model
+	itt_mesh->second->m_visible = !hide;
 }
 
 std::shared_ptr<wr::MeshNode> wmr::ModelParser::GetWRModel(MObject & maya_object)

--- a/src/plugin/parsers/model_parser.hpp
+++ b/src/plugin/parsers/model_parser.hpp
@@ -32,6 +32,10 @@ namespace wmr
 
 		void SetMeshAddCallback(std::function<void(MFnMesh&)> callback);
 
+		// Show/Hide meshes
+		void ShowMesh(MPlug & plug_mesh);
+		void HideMesh(MPlug & plug_mesh);
+
 	private:
 		//callbacks that require private access and are part of the ModelParser.
 		friend void AttributeMeshTransformCallback( MNodeMessage::AttributeMessage msg, MPlug &plug, MPlug &otherPlug, void *clientData );
@@ -42,6 +46,8 @@ namespace wmr
 		std::vector<std::pair<MObject, std::shared_ptr<wr::MeshNode>>> m_object_transform_vector;
 		std::vector<std::pair<MObject, MCallbackId>> m_mesh_added_callback_vector;
 		std::vector<MObject> m_changed_mesh_vector;
+		// Vector of the same type as m_object_transform_vector taht contains hidden meshes
+		decltype(m_object_transform_vector) m_hidden_meshes;
 
 		Renderer& m_renderer;
 

--- a/src/plugin/parsers/model_parser.hpp
+++ b/src/plugin/parsers/model_parser.hpp
@@ -33,8 +33,7 @@ namespace wmr
 		void SetMeshAddCallback(std::function<void(MFnMesh&)> callback);
 
 		// Show/Hide meshes
-		void ShowMesh(MPlug & plug_mesh);
-		void HideMesh(MPlug & plug_mesh);
+		void ToggleMeshVisibility(MPlug & plug_mesh, bool hide);
 
 	private:
 		//callbacks that require private access and are part of the ModelParser.
@@ -46,8 +45,6 @@ namespace wmr
 		std::vector<std::pair<MObject, std::shared_ptr<wr::MeshNode>>> m_object_transform_vector;
 		std::vector<std::pair<MObject, MCallbackId>> m_mesh_added_callback_vector;
 		std::vector<MObject> m_changed_mesh_vector;
-		// Vector of the same type as m_object_transform_vector taht contains hidden meshes
-		decltype(m_object_transform_vector) m_hidden_meshes;
 
 		Renderer& m_renderer;
 

--- a/src/plugin/parsers/scene_graph_parser.cpp
+++ b/src/plugin/parsers/scene_graph_parser.cpp
@@ -99,7 +99,9 @@ void LightRemovedCallback( MObject& node, void* client_data )
 
 void ConnectionAddedCallback(MPlug& src_plug, MPlug& dest_plug, bool made, void* client_data)
 {
- 	auto* material_parser = reinterpret_cast<wmr::MaterialParser*>(client_data);
+ 	auto* scenegraph_parser = reinterpret_cast<wmr::ScenegraphParser*>(client_data);
+	auto* material_parser = &scenegraph_parser->GetMaterialParser();
+	auto* model_parser = &scenegraph_parser->GetModelParser();
 
 	// Get plug types
 	auto src_type = src_plug.node().apiType();
@@ -186,12 +188,12 @@ void ConnectionAddedCallback(MPlug& src_plug, MPlug& dest_plug, bool made, void*
 				// The operation is executed when the connection is made
 				if (made)
 				{
-					// Function to store meshes in a temporary array.
+					model_parser->HideMesh(src_plug);
 				}
 				// The operation is undone when the connection is broken
 				else
 				{
-					// Function to add meshes in a temporary array again.
+					model_parser->ShowMesh(src_plug);
 				}
 			}
 			break;
@@ -248,7 +250,7 @@ void wmr::ScenegraphParser::Initialize()
 	// Connection added (material)
 	addedId = MDGMessage::addConnectionCallback(
 		ConnectionAddedCallback,
-		m_material_parser.get(),
+		this,
 		&status
 	);
 	AddCallbackValidation(status, addedId);

--- a/src/plugin/parsers/scene_graph_parser.cpp
+++ b/src/plugin/parsers/scene_graph_parser.cpp
@@ -185,16 +185,8 @@ void ConnectionAddedCallback(MPlug& src_plug, MPlug& dest_plug, bool made, void*
 		case MFn::kPolyUnite:
 		{
 			if (src_type == MFn::kMesh) {
-				// The operation is executed when the connection is made
-				if (made)
-				{
-					model_parser->HideMesh(src_plug);
-				}
-				// The operation is undone when the connection is broken
-				else
-				{
-					model_parser->ShowMesh(src_plug);
-				}
+				// Toggle the visibility of a mesh by specifiying if the connection was made or broken.
+				model_parser->ToggleMeshVisibility(src_plug, made);
 			}
 			break;
 		}


### PR DESCRIPTION
This PR fixes an issue where ghost models appear after combine/boolean operations. It fixes #66.

## Description
Combining and doing boolean operations on meshes caused ghost models to appear. These models weren't controllable anymore by anything, therefore they are ghost models. More information about this in #66.

## Motivation and Context
This change is required to improve the quality of WispForMaya as well as the workflow of artists. Annoying ghost models don't appear any more and undoing these actions don't crash the application anymore either.

## Screenshots:
The fix is shown [here](https://gyazo.com/b981478f8d0e2f0b819f58f8eea992db.gif) in live action.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
