### PR TITLE
Fix duplicate vertices

### DIFF
--- a/src/plugin/renderer/texture_manager.cpp
+++ b/src/plugin/renderer/texture_manager.cpp
@@ -103,7 +103,7 @@ namespace wmr
 		{
 			// Only reference left to this texture is the one that's in the unordered_map,
 			// so the texture can be deleted.
-			m_texture_pool->Unload(*m_texture_container[hash]);
+			m_texture_pool->MarkForUnload(*m_texture_container[hash], 0);
 			m_texture_container.erase(hash);
 			
 			// Removed the texture from the texture pool


### PR DESCRIPTION
This PR prevents duplicate vertices in meshes. It checks if a vertex has already been processed and makes sure to use the index buffer instead.
It also includes the latest version of Wisp (with the necessary changes to build & run the plugin).

## Description
Vertices used to be duplicated and the list of vertices used to be as big as the list of indices. This PR prevents that and makes sure that there are NO duplicated vertices. A list of indices is made as well.

## Motivation and Context
We want to reduce memory usage in the trade-off of performance decrease (not noticeable with smaller meshes).

## How Has This Been Tested?
A plane has been created in Maya. This plane is a grid of vertices and should only have 121 unique vertices and 600 indices. As you can see in the screenshot, this is now a reality (instead of a list of 600 vertices and 600 indices).

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/18393968/58643103-efeb7380-82fe-11e9-89fc-e653f0d090f3.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
