### PR TITLE
Feature texture unloading

### DIFF
--- a/src/plugin/renderer/material_manager.cpp
+++ b/src/plugin/renderer/material_manager.cpp
@@ -10,6 +10,7 @@
 #include "d3d12/d3d12_renderer.hpp"
 #include "scene_graph/mesh_node.hpp"
 #include "util/log.hpp"
+#include "texture_manager.hpp"
 
 #include <maya/MFnMesh.h>
 #include <maya/MFnTransform.h>
@@ -26,9 +27,9 @@ wmr::MaterialManager::MaterialManager()
 void wmr::MaterialManager::Initialize()
 {
 	const auto& renderer = dynamic_cast<const ViewportRendererOverride*>(MHWRender::MRenderer::theRenderer()->findRenderOverride(settings::VIEWPORT_OVERRIDE_NAME))->GetRenderer();
-	m_texture_pool_ptr = renderer.GetTextureManager().GetTexturePool().get();
+	m_texture_manager = &renderer.GetTextureManager();
 	m_material_pool = renderer.GetD3D12Renderer().CreateMaterialPool(0);
-	m_default_material_handle = m_material_pool->Create(m_texture_pool_ptr);
+	m_default_material_handle = m_material_pool->Create(&*m_texture_manager->GetTexturePool());
 
 	wr::Material* internal_material = m_material_pool->GetMaterial(m_default_material_handle);
 
@@ -69,7 +70,7 @@ wmr::SurfaceShaderShadingEngineRelation * wmr::MaterialManager::OnCreateSurfaceS
 	}
 	// Surface shader doesn't have a material assigned to it yet
 	// Create Wisp Material handle
-	wr::MaterialHandle material_handle = m_material_pool->Create(m_texture_pool_ptr);
+	wr::MaterialHandle material_handle = m_material_pool->Create(&*m_texture_manager->GetTexturePool());
 	// Create relationship between surface shader and shading engine
 	m_surface_shader_shading_relations.push_back({
 		material_handle,		// Wisp Material handle
@@ -109,6 +110,41 @@ void wmr::MaterialManager::OnRemoveSurfaceShader(MPlug & surface_shader)
 				}
 			}
 			it->shading_engines.pop_back();
+		}
+
+		// Clear all textures
+		wr::Material* m = m_material_pool->GetMaterial(it->material_handle);
+		{
+			// Clear albedo texture
+			if (m->HasTexture(wr::TextureType::ALBEDO)) {
+				m_texture_manager->MarkTextureUnused(m->GetTexture(wr::TextureType::ALBEDO));
+				m->ClearTexture(wr::TextureType::ALBEDO);
+			}
+			// Clear AO texture
+			if (m->HasTexture(wr::TextureType::AO)) {
+				m_texture_manager->MarkTextureUnused(m->GetTexture(wr::TextureType::AO));
+				m->ClearTexture(wr::TextureType::AO);
+			}
+			// Clear emissive texture
+			if (m->HasTexture(wr::TextureType::EMISSIVE)) {
+				m_texture_manager->MarkTextureUnused(m->GetTexture(wr::TextureType::EMISSIVE));
+				m->ClearTexture(wr::TextureType::EMISSIVE);
+			}
+			// Clear metallic texture
+			if (m->HasTexture(wr::TextureType::METALLIC)) {
+				m_texture_manager->MarkTextureUnused(m->GetTexture(wr::TextureType::METALLIC));
+				m->ClearTexture(wr::TextureType::METALLIC);
+			}
+			// Clear normal texture
+			if (m->HasTexture(wr::TextureType::NORMAL)) {
+				m_texture_manager->MarkTextureUnused(m->GetTexture(wr::TextureType::NORMAL));
+				m->ClearTexture(wr::TextureType::NORMAL);
+			}
+			// Clear roughness texture
+			if (m->HasTexture(wr::TextureType::ROUGHNESS)) {
+				m_texture_manager->MarkTextureUnused(m->GetTexture(wr::TextureType::ROUGHNESS));
+				m->ClearTexture(wr::TextureType::ROUGHNESS);
+			}
 		}
 
 		// Remove surface shader from vector
@@ -152,7 +188,7 @@ wr::MaterialHandle wmr::MaterialManager::ConnectShaderToShadingEngine(MPlug & su
 	}
 	// Surface shader doesn't have a material assigned to it yet
 	// Create Wisp Material handle
-	wr::MaterialHandle material_handle = m_material_pool->Create(m_texture_pool_ptr);
+	wr::MaterialHandle material_handle = m_material_pool->Create(&*m_texture_manager->GetTexturePool());
 	// Create a vector for the shading engines
 	std::vector<MObject> shading_engines;
 	shading_engines.push_back(shading_engine);

--- a/src/plugin/renderer/material_manager.cpp
+++ b/src/plugin/renderer/material_manager.cpp
@@ -29,7 +29,7 @@ void wmr::MaterialManager::Initialize()
 	const auto& renderer = dynamic_cast<const ViewportRendererOverride*>(MHWRender::MRenderer::theRenderer()->findRenderOverride(settings::VIEWPORT_OVERRIDE_NAME))->GetRenderer();
 	m_texture_manager = &renderer.GetTextureManager();
 	m_material_pool = renderer.GetD3D12Renderer().CreateMaterialPool(0);
-	m_default_material_handle = m_material_pool->Create(&*m_texture_manager->GetTexturePool());
+	m_default_material_handle = m_material_pool->Create(m_texture_manager->GetTexturePool().get());
 
 	wr::Material* internal_material = m_material_pool->GetMaterial(m_default_material_handle);
 
@@ -188,7 +188,7 @@ wr::MaterialHandle wmr::MaterialManager::ConnectShaderToShadingEngine(MPlug & su
 	}
 	// Surface shader doesn't have a material assigned to it yet
 	// Create Wisp Material handle
-	wr::MaterialHandle material_handle = m_material_pool->Create(&*m_texture_manager->GetTexturePool());
+	wr::MaterialHandle material_handle = m_material_pool->Create(m_texture_manager->GetTexturePool().get());
 	// Create a vector for the shading engines
 	std::vector<MObject> shading_engines;
 	shading_engines.push_back(shading_engine);

--- a/src/plugin/renderer/material_manager.hpp
+++ b/src/plugin/renderer/material_manager.hpp
@@ -18,6 +18,7 @@ namespace wr
 namespace wmr
 {
 	class ScenegraphParser;
+	class TextureManager;
 
 	struct MeshShadingEngineRelation
 	{
@@ -93,7 +94,7 @@ namespace wmr
 		
 		wr::MaterialHandle m_default_material_handle;
 		std::shared_ptr<wr::MaterialPool> m_material_pool;
-		wr::TexturePool* m_texture_pool_ptr; //! Does not need to be deleted, it's just a way to get hold of the pool
+		wmr::TextureManager* m_texture_manager;
 
 		//! Relationship array of meshes and shading engines (shader groups)
 		// Don't need a struct if mesh can be extracted from a shading engine

--- a/src/plugin/renderer/renderer.cpp
+++ b/src/plugin/renderer/renderer.cpp
@@ -21,7 +21,7 @@ wmr::Renderer::Renderer()
 	m_render_system			= std::make_unique<wr::D3D12RenderSystem>();
 	m_window				= std::make_unique<wr::Window>(GetModuleHandleA(nullptr), "Wisp hidden window", 1280, 720, false);
 	m_model_manager			= std::make_unique<ModelManager>();
-	m_texture_manager		= std::make_unique<TextureManager>();
+	m_texture_manager		= std::make_unique<TextureManager>(this);
 	m_material_manager		= std::make_unique<MaterialManager>();
 	m_framegraph_manager	= std::make_unique<FrameGraphManager>();
 

--- a/src/plugin/renderer/texture_manager.hpp
+++ b/src/plugin/renderer/texture_manager.hpp
@@ -22,7 +22,7 @@ namespace wmr
 	class TextureManager
 	{
 	public:
-		TextureManager();
+		TextureManager(Renderer *renderer);
 		~TextureManager() = default;
 
 		//! Initialization
@@ -38,7 +38,7 @@ namespace wmr
 		const wr::TextureHandle GetDefaultSkybox() const noexcept;
 
 		//! Get a texture handle by name
-		const std::shared_ptr<wr::TextureHandle> GetTexture(const char* identifier) noexcept;
+		const std::shared_ptr<wr::TextureHandle> GetTexture(const wr::TextureHandle& texture_handle) noexcept;
 
 		const std::shared_ptr<wr::TexturePool> GetTexturePool() noexcept;
 
@@ -48,7 +48,7 @@ namespace wmr
 		 *  function will deallocate the memory automatically.
 		 *  
 		 *  \returns : Whether application actually deallocates the memory in Wisp. */
-		bool MarkTextureUnused(const char* identifier) noexcept;
+		bool MarkTextureUnused(const wr::TextureHandle& texture_handle) noexcept;
 
 	private:
 		//! Holds all texture handles of the texture manager


### PR DESCRIPTION
Added support for texture unloading. Whenever a material is removed, it checks if any textures are used. Whenever a texture is in the 'to be removed'-material, it marks it for unload/unused IF the texture isn't used anywhere else.