### PR TITLE
Feature popup

### DIFF
--- a/module/wisp/bin/resources/hybrid_switch.txt
+++ b/module/wisp/bin/resources/hybrid_switch.txt
@@ -1,0 +1,9 @@
+Your device doesn't seem to support DXR (the official DirectX Ray Tracing API).
+
+This could have several reasons:
+    1) Wrong SDK version. (Required: `Windows 10 October 2018 Update SDK (17763)`)
+    2) Wrong OS version. (Required: 1809 (17763.107))
+    3) DX12 GPU with a incompatible DirectX Raytracing driver. (NVIDIA: driver version 415 or higher, AMD: Consult Vendor for availability)
+
+If you still want to continue this action, try to open the Real-Time Final Render Preview render mode again.
+BE AWARE! Because DXR is not supported, it is using a quite unstable Fallback API. This may crash Maya and you may lose your work! Be sure to save your work before you continue!

--- a/module/wisp/bin/resources/notify.txt
+++ b/module/wisp/bin/resources/notify.txt
@@ -10,4 +10,4 @@ https://github.com/TeamWisp/WispForMaya/issues (requires GitHub account)
 
 Either way, enjoy WispForMaya!
 
-\- Team Wisp
+ - Team Wisp

--- a/src/miscellaneous/maya_popup.cpp
+++ b/src/miscellaneous/maya_popup.cpp
@@ -1,6 +1,6 @@
 #include "maya_popup.hpp"
 
-// Maya includesd
+// Maya includes
 #include <maya/MGlobal.h>
 #include <maya/MString.h>
 

--- a/src/miscellaneous/maya_popup.cpp
+++ b/src/miscellaneous/maya_popup.cpp
@@ -21,7 +21,10 @@ namespace wmr
 
 	void MayaPopup::Spawn(std::stringstream &content, const Options &options) noexcept
 	{
-		constexpr const char const* text_prefix = "text -ww on -align \"left\" -rs on -w 400 \"";
+		std::string str_text_prefix = "text -ww on -align \"left\" -rs on -w ";
+		str_text_prefix += std::to_string(options.width);
+		str_text_prefix += " \"";
+		const char const* text_prefix = str_text_prefix.c_str();
 		constexpr const char const* text_postfix = "\";\n";
 
 		// Create window

--- a/src/miscellaneous/maya_popup.cpp
+++ b/src/miscellaneous/maya_popup.cpp
@@ -1,0 +1,84 @@
+#include "maya_popup.hpp"
+
+// Maya includesd
+#include <maya/MGlobal.h>
+#include <maya/MString.h>
+
+// STD includes
+#include <fstream>
+#include <sstream>
+
+
+namespace wmr
+{
+	void MayaPopup::Spawn(std::stringstream &content, const Options& options) noexcept
+	{
+		constexpr const char const* text_prefix = "text - ww on - align \"left\" - rs on - w 400 \"";
+		constexpr const char const* text_postfix = "\";";
+
+		// Create window
+		MString notify_command("window -title \"Wisp\" -sizeable off -maximizeButton off -minimizeButton off WispInfoWindow;\n");
+
+		// Set layout
+		notify_command += "rowColumnLayout -columnOffset 1 \"both\" 10 -rowOffset 1 \"both\" 15 -nc 1 -cal 1 \"left\";\n";
+
+		// Print text
+		std::string line;
+		while (std::getline(content, line))
+		{
+			// Add a space if an empty line was found
+			if (line.length() <= 0)
+			{
+				line += " ";
+			}
+
+			// Text settings
+			notify_command += text_prefix;
+			// Add text
+			notify_command += line.c_str();
+			// Add end quote
+			notify_command += text_postfix;
+		}
+
+		// Add empty line for proper spacing
+		notify_command += text_prefix;
+		notify_command += " ";
+		notify_command += text_postfix;
+
+		// Add button to close
+		if (options.btn_ok)
+		{
+			notify_command += "button - enable on - command \"deleteUI WispInfoWindow\" \"Ok\";\n";
+
+			// Add spacing below the button
+			notify_command += text_prefix;
+			notify_command += " ";
+			notify_command += text_postfix;
+		}
+
+		// Display window
+		notify_command += "showWindow WispInfoWindow;";
+
+		MGlobal::displayInfo(notify_command);
+
+		// Execute display window command
+		MGlobal::executeCommand(notify_command);
+	}
+
+	bool MayaPopup::SpawnFromFile(const char* path, const Options& options) noexcept
+	{
+		// Get file
+		std::ifstream infile(path);
+		if (!infile.is_open())
+		{
+			std::stringstream s;
+			s << infile.rdbuf();
+			infile.close();
+
+			MayaPopup::Spawn(s, options);
+			return true;
+		}
+		return false;
+	}
+}
+

--- a/src/miscellaneous/maya_popup.cpp
+++ b/src/miscellaneous/maya_popup.cpp
@@ -11,13 +11,30 @@
 
 namespace wmr
 {
-	void MayaPopup::Spawn(std::stringstream &content, const Options& options) noexcept
+	void MayaPopup::Spawn(std::string& content, const Options& options) noexcept
 	{
-		constexpr const char const* text_prefix = "text - ww on - align \"left\" - rs on - w 400 \"";
-		constexpr const char const* text_postfix = "\";";
+		std::stringstream s;
+		s << content.c_str();
+
+		MayaPopup::Spawn(s, options);
+	}
+
+	void MayaPopup::Spawn(std::stringstream &content, const Options &options) noexcept
+	{
+		constexpr const char const* text_prefix = "text -ww on -align \"left\" -rs on -w 400 \"";
+		constexpr const char const* text_postfix = "\";\n";
 
 		// Create window
-		MString notify_command("window -title \"Wisp\" -sizeable off -maximizeButton off -minimizeButton off WispInfoWindow;\n");
+		MString notify_command("window -title \"");
+		
+		// Window settings
+		// Window title
+		notify_command += options.window_title.c_str();
+		// Other options
+		notify_command += "\" -sizeable off -maximizeButton off -minimizeButton off ";
+		// Window "behind the scenes" name
+		notify_command += options.window_name.c_str();
+		notify_command += ";\n";
 
 		// Set layout
 		notify_command += "rowColumnLayout -columnOffset 1 \"both\" 10 -rowOffset 1 \"both\" 15 -nc 1 -cal 1 \"left\";\n";
@@ -48,7 +65,9 @@ namespace wmr
 		// Add button to close
 		if (options.btn_ok)
 		{
-			notify_command += "button - enable on - command \"deleteUI WispInfoWindow\" \"Ok\";\n";
+			notify_command += "button -enable on -command \"deleteUI ";
+			notify_command += options.window_name.c_str();
+			notify_command += "\" \"Ok\";\n";
 
 			// Add spacing below the button
 			notify_command += text_prefix;
@@ -57,7 +76,9 @@ namespace wmr
 		}
 
 		// Display window
-		notify_command += "showWindow WispInfoWindow;";
+		notify_command += "showWindow ";
+		notify_command += options.window_name.c_str(); 
+		notify_command += ";";
 
 		MGlobal::displayInfo(notify_command);
 
@@ -69,7 +90,7 @@ namespace wmr
 	{
 		// Get file
 		std::ifstream infile(path);
-		if (!infile.is_open())
+		if (infile.is_open())
 		{
 			std::stringstream s;
 			s << infile.rdbuf();

--- a/src/miscellaneous/maya_popup.hpp
+++ b/src/miscellaneous/maya_popup.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+//STD includes
+#include <string>
+
+//! Generic plug-in namespace (Wisp Maya Renderer)
+namespace wmr
+{
+	//! Maya popup spawner
+	/*! This class can spawn popup's in Maya. All functions are static, so there's no use of actually instancing the class. */
+	class MayaPopup final
+	{
+	public:
+		struct Options
+		{
+			bool btn_ok = true;
+		};
+
+		//! Spawn a popup with some text
+		/*!
+			\param content The popup content in plain ASCII text.
+			\param options [Optional] The options for this popup 
+		*/
+		static void Spawn(std::stringstream &content, const Options &options = Options()) noexcept;
+
+		//! Spawn a popup with text loaded from a file
+		/*!
+			\param path The path to the location of the file
+			\param options [Optional] The options for this popup
+			\return A boolean that defines if the file could be loaded or not. `true` is it was loaded correctly.
+		*/
+		static bool SpawnFromFile(const char * path, const Options& options = Options()) noexcept;
+
+	private:
+
+	};
+}

--- a/src/miscellaneous/maya_popup.hpp
+++ b/src/miscellaneous/maya_popup.hpp
@@ -16,6 +16,7 @@ namespace wmr
 			bool btn_ok = true; /**< Defines if the popup should have an "Ok" button */
 			std::string window_title = std::string("WispForMaya"); /**< The title of the window */
 			std::string window_name = std::string("unique_name"); /**< A unique name for the maya window */
+			uint32_t width = 400; /**< The width of the popup */
 		};
 
 		//! Spawn a popup with some text from a string

--- a/src/miscellaneous/maya_popup.hpp
+++ b/src/miscellaneous/maya_popup.hpp
@@ -13,10 +13,19 @@ namespace wmr
 	public:
 		struct Options
 		{
-			bool btn_ok = true;
+			bool btn_ok = true; /**< Defines if the popup should have an "Ok" button */
+			std::string window_title = std::string("WispForMaya"); /**< The title of the window */
+			std::string window_name = std::string("unique_name"); /**< A unique name for the maya window */
 		};
 
-		//! Spawn a popup with some text
+		//! Spawn a popup with some text from a string
+		/*!
+			\param content The popup content in plain ASCII text.
+			\param options [Optional] The options for this popup
+		*/
+		static void Spawn(std::string& content, const Options& options = Options()) noexcept;
+
+		//! Spawn a popup with some text from a stringstream
 		/*!
 			\param content The popup content in plain ASCII text.
 			\param options [Optional] The options for this popup 

--- a/src/miscellaneous/maya_popup.hpp
+++ b/src/miscellaneous/maya_popup.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-//STD includes
+// STD includes
 #include <string>
 
 //! Generic plug-in namespace (Wisp Maya Renderer)
@@ -40,8 +40,6 @@ namespace wmr
 			\return A boolean that defines if the file could be loaded or not. `true` is it was loaded correctly.
 		*/
 		static bool SpawnFromFile(const char * path, const Options& options = Options()) noexcept;
-
-	private:
 
 	};
 }

--- a/src/plugin/renderer/render_pipeline_select_command.cpp
+++ b/src/plugin/renderer/render_pipeline_select_command.cpp
@@ -61,7 +61,8 @@ MStatus wmr::RenderPipelineSelectCommand::doIt(const MArgList& args)
 
 			MayaPopup::SpawnFromFile("resources/hybrid_switch.txt", options);
 		}
-		else {
+		else 
+		{
 			frame_graph.SetType(RendererFrameGraphType::HYBRID_RAY_TRACING);
 		}
 	}

--- a/src/plugin/renderer/render_pipeline_select_command.cpp
+++ b/src/plugin/renderer/render_pipeline_select_command.cpp
@@ -1,9 +1,11 @@
 #include "render_pipeline_select_command.hpp"
 
 // Wisp
+#include <d3d12/d3d12_renderer.hpp>
 #include <util/log.hpp>
 
 // Wisp plug-in
+#include "miscellaneous/maya_popup.hpp"
 #include "plugin/framegraph/frame_graph_manager.hpp"
 #include "plugin/viewport_renderer_override.hpp"
 #include "renderer.hpp"
@@ -47,7 +49,21 @@ MStatus wmr::RenderPipelineSelectCommand::doIt(const MArgList& args)
 	}
 	else if (hybrid_set)
 	{
-		frame_graph.SetType(RendererFrameGraphType::HYBRID_RAY_TRACING);
+		static bool first_time_hybrid = true;
+		if (first_time_hybrid && !renderer.GetD3D12Renderer().m_device->m_dxr_support)
+		{
+			first_time_hybrid = false;
+
+			// Open warning popup
+			MayaPopup::Options options;
+			options.window_name = "hybrid_open_popup";
+			options.width = 500;
+
+			MayaPopup::SpawnFromFile("resources/hybrid_switch.txt", options);
+		}
+		else {
+			frame_graph.SetType(RendererFrameGraphType::HYBRID_RAY_TRACING);
+		}
 	}
 	else
 	{

--- a/src/plugin/viewport_renderer_override.cpp
+++ b/src/plugin/viewport_renderer_override.cpp
@@ -12,6 +12,7 @@
 #include "render_operations/renderer_update_operation.hpp"
 #include "render_operations/screen_render_operation.hpp"
 #include "renderer/renderer.hpp"
+#include "miscellaneous/maya_popup.hpp"
 
 // Wisp rendering framework
 #include "d3d12/d3d12_renderer.hpp"
@@ -33,8 +34,6 @@
 // C++ standard
 #include <algorithm>
 #include <memory>
-#include <fstream>
-#include <sstream>
 #include <string>
 
 static std::shared_ptr<wr::TexturePool> texture_pool;
@@ -288,20 +287,11 @@ namespace wmr
 	}
 	void ViewportRendererOverride::InitialNotifyUser()
 	{
-		const char const* text_prefix = "text - ww on - align \"left\" - rs on - w 400 \"";
-		const char const* text_postfix = "\";";
-
-		// Create window
-		MString notify_command("window -title \"Wisp\" -sizeable off -maximizeButton off -minimizeButton off WispInfoWindow;\n");
-
-		// Set layout
-		notify_command += "rowColumnLayout -columnOffset 1 \"both\" 10 -rowOffset 1 \"both\" 15 -nc 1 -cal 1 \"left\";\n";
-
-		// Get file
-		std::ifstream infile("resources/notify.txt");
-		// Show hardcoded popup if the contents couldn't be found
-		if (!infile.is_open()) {
+		if (!MayaPopup::SpawnFromFile("resources/notify.txt"))
+		{
 			LOGE("Couldn't find notify.txt! Notifying the user with a default message.");
+
+			/*
 			// Show old (may be outdated) popup. Also warn the user that the popup may be outdated.
 			MGlobal::executeCommand(
 				"window -title \"Wisp\" -sizeable off -maximizeButton off -minimizeButton off WispInfoWindow;\
@@ -321,47 +311,7 @@ namespace wmr
 				text - ww on - align \"left\" - rs on - w 400 \" \";\
 				showWindow WispInfoWindow;"
 			);
-
-			return;
+			*/
 		}
-		else {
-			// Print text
-			std::string line;
-			while (std::getline(infile, line)) {
-				// Add a space if an empty line was found
-				if (line.length() <= 0) {
-					line += " ";
-				}
-
-				// Text settings
-				notify_command += text_prefix;
-				// Add text
-				notify_command += line.c_str();
-				// Add end quote
-				notify_command += text_postfix;
-			}
-			infile.close();
-		}
-
-		// Add empty line for proper spacing
-		notify_command += text_prefix;
-		notify_command += " ";
-		notify_command += text_postfix;
-
-		// Add button to close
-		notify_command += "button - enable on - command \"deleteUI WispInfoWindow\" \"Ok\";\n";
-		
-		// Add spacing below the button
-		notify_command += text_prefix;
-		notify_command += " ";
-		notify_command += text_postfix;
-
-		// Display window
-		notify_command += "showWindow WispInfoWindow;";
-
-		MGlobal::displayInfo(notify_command);
-
-		// Execute display window command
-		MGlobal::executeCommand(notify_command);
 	}
 }

--- a/src/plugin/viewport_renderer_override.cpp
+++ b/src/plugin/viewport_renderer_override.cpp
@@ -287,31 +287,27 @@ namespace wmr
 	}
 	void ViewportRendererOverride::InitialNotifyUser()
 	{
-		if (!MayaPopup::SpawnFromFile("resources/notify.txt"))
+		MayaPopup::Options options;
+		options.window_name = "initial_wisp";
+
+		if (!MayaPopup::SpawnFromFile("resources/notify.txt", options))
 		{
 			LOGE("Couldn't find notify.txt! Notifying the user with a default message.");
 
-			/*
 			// Show old (may be outdated) popup. Also warn the user that the popup may be outdated.
-			MGlobal::executeCommand(
-				"window -title \"Wisp\" -sizeable off -maximizeButton off -minimizeButton off WispInfoWindow;\
-				rowColumnLayout - columnOffset 1 \"both\" 10 - rowOffset 1 \"both\" 15 - nc 1 - cal 1 \"left\";\
-				text - ww on - align \"left\" - rs on - w 400 \"Hey there!\";\
-				text - ww on - align \"left\" - rs on - w 400 \"Something went wrong with loading the contents of this window. Please keep in mind that the following could be outdated.\";\
-				text - ww on - align \"left\" - rs on - w 400 \"Wisp is heavily under development which means that you might encounter weird, annoying and sometimes work-losing bugs/crashes. Don't worry we are working on them!\";\
-				text - ww on - align \"left\" - rs on - w 400 \" \";\
-				text - ww on - align \"left\" - rs on - w 400 \"Bug and feature updates will be released frequenty. If you encounter bugs or want to provide us with feedback, contact us on discord:\";\
-				text - ww on - align \"left\" - rs on - w 400 \- hl on - label \"https://discordapp.com/invite/KthSUvs\" \"https://discordapp.com/invite/KthSUvs\";\
-				text - ww on - align \"left\" - rs on - w 400 \" \";\
-				text - ww on - align \"left\" - rs on - w 400 \"Either way, enjoy Wisp!\";\
-				text - ww on - align \"left\" - rs on - w 400 \" \";\
-				text - ww on - align \"left\" - rs on - w 400 \"/ Team Wisp\";\
-				text - ww on - align \"left\" - rs on - w 400 \" \";\
-				button - enable on - command \"deleteUI WispInfoWindow\" \"Ok\";\
-				text - ww on - align \"left\" - rs on - w 400 \" \";\
-				showWindow WispInfoWindow;"
-			);
-			*/
+			std::string temp_content = std::string(
+				"Hey there!\
+				Something went wrong with loading the contents of this window. Please keep in mind that the following could be outdated.\
+				Wisp is heavily under development which means that you might encounter weird, annoying and sometimes work-losing bugs/crashes. Don't worry we are working on them!\
+				\
+				Bug and feature updates will be released frequenty. If you encounter bugs or want to provide us with feedback, contact us on discord:\
+				https://discordapp.com/invite/KthSUvs\
+				\
+				Either way, enjoy Wisp!\
+				\
+				 / Team Wisp");
+
+			MayaPopup::Spawn(temp_content, options);
 		}
 	}
 }

--- a/src/plugin/viewport_renderer_override.cpp
+++ b/src/plugin/viewport_renderer_override.cpp
@@ -296,16 +296,16 @@ namespace wmr
 
 			// Show old (may be outdated) popup. Also warn the user that the popup may be outdated.
 			std::string temp_content = std::string(
-				"Hey there!\
-				Something went wrong with loading the contents of this window. Please keep in mind that the following could be outdated.\
-				Wisp is heavily under development which means that you might encounter weird, annoying and sometimes work-losing bugs/crashes. Don't worry we are working on them!\
-				\
-				Bug and feature updates will be released frequenty. If you encounter bugs or want to provide us with feedback, contact us on discord:\
-				https://discordapp.com/invite/KthSUvs\
-				\
-				Either way, enjoy Wisp!\
-				\
-				 / Team Wisp");
+"Hey there!\n\
+Something went wrong with loading the contents of this window. Please keep in mind that the following could be outdated.\n\
+Wisp is heavily under development which means that you might encounter weird, annoying and sometimes work-losing bugs/crashes. Don't worry we are working on them!\n\
+\n\
+Bug and feature updates will be released frequenty. If you encounter bugs or want to provide us with feedback, contact us on discord:\n\
+https://discordapp.com/invite/KthSUvs\n\
+\n\
+Either way, enjoy Wisp!\n\
+\n\
+/ Team Wisp");
 
 			MayaPopup::Spawn(temp_content, options);
 		}


### PR DESCRIPTION
This pull request adds a class to spawn popups within Maya.
It also improved the initial popup on startup (cleaned up a lot of hardcoded code).
It also adds a 'one-time' popup on a switch to the hybrid pipeline (Real-time Final Render Preview). This popup only opens if dxr is not supported. This warns the user that it may crash Maya. The user will have to open the pipeline again if he's really sure about it.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
