### PR TITLE
Improve material binding

### DIFF
--- a/src/plugin/parsers/material_parser.cpp
+++ b/src/plugin/parsers/material_parser.cpp
@@ -494,20 +494,18 @@ wmr::ArnoldStandardSurfaceShaderData wmr::MaterialParser::ParseArnoldStandardSur
 
 	// Get all PBR variables
 	auto diffuse_color_plug			= GetPlugByName(plug,ArnoldStandardSurfaceShaderData::diffuse_color_plug_name);
-	auto diffuse_roughness_plug		= GetPlugByName(plug,ArnoldStandardSurfaceShaderData::diffuse_roughness_plug_name);
 	auto metalness_plug				= GetPlugByName(plug,ArnoldStandardSurfaceShaderData::metalness_plug_name);
 	auto emission_plug				= GetPlugByName(plug,ArnoldStandardSurfaceShaderData::emission_plug_name);
 	auto emission_color_plug		= GetPlugByName(plug,ArnoldStandardSurfaceShaderData::emission_color_plug_name);
-	auto specular_roughness_plug	= GetPlugByName(plug,ArnoldStandardSurfaceShaderData::specular_roughness_plug_name);
+	auto roughness_plug				= GetPlugByName(plug,ArnoldStandardSurfaceShaderData::roughness_plug_name);
 	auto bump_map_plug				= GetPlugByName(plug,ArnoldStandardSurfaceShaderData::bump_map_plug_name);
 
 	// Attempt to retrieve a texture for each PBR variable
 	auto diffuse_color_texture_path			= GetPlugTexture(diffuse_color_plug);
-	auto diffuse_roughness_texture_path		= GetPlugTexture(diffuse_roughness_plug);
 	auto metalness_texture_path				= GetPlugTexture(metalness_plug);
 	auto emission_texture_path				= GetPlugTexture(emission_plug);
 	auto emission_color_texture_path		= GetPlugTexture(emission_color_plug);
-	auto specular_roughness_texture_path	= GetPlugTexture(specular_roughness_plug);
+	auto roughness_texture_path				= GetPlugTexture(roughness_plug);
 	auto bump_map_texture_path				= GetPlugTexture(bump_map_plug);
 
 	// Diffuse color
@@ -527,15 +525,15 @@ wmr::ArnoldStandardSurfaceShaderData wmr::MaterialParser::ParseArnoldStandardSur
 		data.diffuse_color[2] = color.b;
 	}
 
-	// Diffuse roughness
-	if (diffuse_roughness_texture_path.has_value())
+	// Roughness
+	if (roughness_texture_path.has_value())
 	{
-		data.using_diffuse_roughness_value = false;
-		data.diffuse_roughness_texture_path = diffuse_roughness_texture_path.value().asChar();
+		data.using_roughness_value = false;
+		data.roughness_texture_path = roughness_texture_path.value().asChar();
 	}
 	else
 	{
-		dep_node_fn.findPlug(ArnoldStandardSurfaceShaderData::diffuse_roughness_plug_name).getValue(data.diffuse_roughness);
+		dep_node_fn.findPlug(ArnoldStandardSurfaceShaderData::roughness_plug_name).getValue(data.roughness);
 	}
 
 	// Metalness
@@ -565,17 +563,6 @@ wmr::ArnoldStandardSurfaceShaderData wmr::MaterialParser::ParseArnoldStandardSur
 	{
 		data.using_emission_color_value = false;
 		data.emission_color_texture_path = emission_color_texture_path.value().asChar();
-	}
-
-	// Specular roughness
-	if (specular_roughness_texture_path.has_value())
-	{
-		data.using_specular_roughness_value = false;
-		data.specular_roughness_texture_path = specular_roughness_texture_path.value().asChar();
-	}
-	else
-	{
-		dep_node_fn.findPlug(ArnoldStandardSurfaceShaderData::specular_roughness_plug_name).getValue(data.specular_roughness);
 	}
 
 	// Bump map
@@ -676,14 +663,14 @@ void wmr::MaterialParser::ConfigureWispMaterial(const wmr::ArnoldStandardSurface
 	}
 
 	// Roughness
-	if (data.using_specular_roughness_value)
+	if (data.using_roughness_value)
 	{
-		material->SetConstant<wr::MaterialConstant::ROUGHNESS>(data.diffuse_roughness);
+		material->SetConstant<wr::MaterialConstant::ROUGHNESS>(data.roughness);
 	}
 	else
 	{
 		// Request new Wisp textures
-		auto roughness_texture = texture_manager.CreateTexture(data.specular_roughness_texture_path);
+		auto roughness_texture = texture_manager.CreateTexture(data.roughness_texture_path);
 
 		if (roughness_texture != nullptr) {
 			// Use this texture as the material roughness texture

--- a/src/plugin/parsers/material_parser.cpp
+++ b/src/plugin/parsers/material_parser.cpp
@@ -74,7 +74,7 @@ namespace wmr
 		wr::Material* material = material_manager.GetWispMaterial(material_handle);
 
 		// Get plug name that has changed value
-		MString changedPlugName = plug.partialName(false, false, false, false, false, true); MGlobal::displayInfo(changedPlugName);
+		MString changedPlugName = plug.partialName(false, false, false, false, false, true);
 
 		// Apply changes to material
 		MFnDependencyNode fn_dep_material(node);

--- a/src/plugin/parsers/shader_structs.hpp
+++ b/src/plugin/parsers/shader_structs.hpp
@@ -58,7 +58,8 @@ namespace wmr
 		static const constexpr char* diffuse_color_plug_name = "baseColor";
 		static const constexpr char* diffuse_roughness_plug_name = "diffuseRoughness";
 		static const constexpr char* metalness_plug_name = "metalness";
-		static const constexpr char* specular_color_plug_name = "specularColor";
+		static const constexpr char* emission_plug_name = "emission";
+		static const constexpr char* emission_color_plug_name = "emissionColor";
 		static const constexpr char* specular_roughness_plug_name = "specularRoughness";
 		static const constexpr char* bump_map_plug_name = "normalCamera";
 
@@ -66,14 +67,15 @@ namespace wmr
 		bool using_diffuse_color_value = true;
 		bool using_diffuse_roughness_value = true;
 		bool using_metalness_value = true;
-		bool using_specular_color_value = true;
+		bool using_emission_value = true;
+		bool using_emission_color_value = true;
 		bool using_specular_roughness_value = true;
 
 		// Values
 		float diffuse_color[3] = {0.0f, 0.0f, 0.0f};
 		float diffuse_roughness = 0.0f;
 		float metalness = 0.0f;
-		float specular_color[3] = {0.0f, 0.0f, 0.0f};
+		float emission = 0.0f;
 		float specular_roughness = 0.0f;
 
 		// Files
@@ -81,7 +83,7 @@ namespace wmr
 		const char* diffuse_color_texture_path = "";
 		const char* diffuse_roughness_texture_path = "";
 		const char* metalness_texture_path = "";
-		const char* specular_color_texture_path = "";
+		const char* emission_color_texture_path = "";
 		const char* specular_roughness_texture_path = "";
 	};
 }

--- a/src/plugin/parsers/shader_structs.hpp
+++ b/src/plugin/parsers/shader_structs.hpp
@@ -56,34 +56,30 @@ namespace wmr
 	{
 		// Plug names to retrieve values
 		static const constexpr char* diffuse_color_plug_name = "baseColor";
-		static const constexpr char* diffuse_roughness_plug_name = "diffuseRoughness";
 		static const constexpr char* metalness_plug_name = "metalness";
 		static const constexpr char* emission_plug_name = "emission";
 		static const constexpr char* emission_color_plug_name = "emissionColor";
-		static const constexpr char* specular_roughness_plug_name = "specularRoughness";
+		static const constexpr char* roughness_plug_name = "specularRoughness";
 		static const constexpr char* bump_map_plug_name = "normalCamera";
 
 		// Flags
 		bool using_diffuse_color_value = true;
-		bool using_diffuse_roughness_value = true;
 		bool using_metalness_value = true;
 		bool using_emission_value = true;
 		bool using_emission_color_value = true;
-		bool using_specular_roughness_value = true;
+		bool using_roughness_value = true;
 
 		// Values
 		float diffuse_color[3] = {0.0f, 0.0f, 0.0f};
-		float diffuse_roughness = 0.0f;
 		float metalness = 0.0f;
 		float emission = 0.0f;
-		float specular_roughness = 0.0f;
+		float roughness = 0.0f;
 
 		// Files
 		const char* bump_map_texture_path = "";
 		const char* diffuse_color_texture_path = "";
-		const char* diffuse_roughness_texture_path = "";
 		const char* metalness_texture_path = "";
 		const char* emission_color_texture_path = "";
-		const char* specular_roughness_texture_path = "";
+		const char* roughness_texture_path = "";
 	};
 }


### PR DESCRIPTION
This PR adds support for emissive textures and weight. It also changes the roughness value from diffuse to specular roughness since the diffuse roughness is locked when metalness is 1.00.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
