### PR TITLE
Fix duplicating

### DIFF
--- a/src/plugin/parsers/model_parser.cpp
+++ b/src/plugin/parsers/model_parser.cpp
@@ -542,7 +542,7 @@ void wmr::ModelParser::SubscribeObject( MObject & maya_object )
 		this,
 		&status
 	);
-
+	 
 	if (status != MS::kSuccess)
 	{
 		LOGC("Could not subscribe object to attribute changed callback.");
@@ -556,7 +556,7 @@ void wmr::ModelParser::SubscribeObject( MObject & maya_object )
 	// When wesh has vertices, manually call the callback function for added mesh
 	if (temp_point_array.length() > 0) {
 		MPlug plug = fn_mesh.findPlug("outMesh", status);
-		AttributeMeshAddedCallback(
+		AttributeMeshAddedCallback( 
 			MNodeMessage::AttributeMessage::kAttributeSet,
 			plug,
 			plug, // Reuse the same mesh plug for `other_plug`. It's not being used, but has to be passed.


### PR DESCRIPTION
This pull request fixes duplicating meshes. This used to not display the duplicated meshes. Only when you start modeling the mesh it appeared.

Tested importing models, duplicating models and intersection operator on two duplicated models.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
